### PR TITLE
Added IndexedDB polyfill to Database Examples

### DIFF
--- a/static/demos/idb-databinding/delete.html
+++ b/static/demos/idb-databinding/delete.html
@@ -1,3 +1,8 @@
+<script src = "http://axemclion.github.com/IndexedDBShim/dist/IndexedDBShim.js"></script>
+<script type = "text/javascript">
+  window.shimIndexedDB  && window.shimIndexedDB.__useShim();
+</script>
+
 <script>
 var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.msIndexedDB;
 

--- a/static/demos/idb-databinding/index_mark3.html
+++ b/static/demos/idb-databinding/index_mark3.html
@@ -8,8 +8,11 @@
 <script src="js/jquery-ui-1.8.20.custom.min.js"></script>
 <script src="js/handlebars-1.0.0.beta.6.js"></script>
 <link href="css/vader/jquery-ui-1.8.20.custom.css" rel="stylesheet">
+<script src = "http://axemclion.github.com/IndexedDBShim/dist/IndexedDBShim.js"></script>
+<script type = "text/javascript">
+	window.shimIndexedDB  && window.shimIndexedDB.__useShim();
+</script>
 <script>
-
 // https://developer.mozilla.org/en/IndexedDB/Using_IndexedDB
 var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.msIndexedDB;
 var IDBTransaction = window.IDBTransaction || window.webkitIDBTransaction;


### PR DESCRIPTION
The polyfill enables the UI data binding to work on browsers like Chrome, Opera and Safari. The polyfill uses WebSQL to emulate the IndexedDB API. 

The data binding example uses "onupgradeneeded" which is not supported by Chrome. For chrome, the IndexedDB polyfill is forced to use WebSQL, so that the exampels work for chrome too. 
