### PR TITLE
increase site speed sampling rate to 50%

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -450,6 +450,7 @@
   <script>
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-15028909-1']);
+  _gaq.push(['_setSiteSpeedSampleRate', 50]);
   _gaq.push(['_trackPageview']);
 
   (function() {


### PR DESCRIPTION
default rate is %1, which is often not enough for page-level analysis.
