### PR TITLE
Blacklist an image to prevent corruption in pagespeed.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -24,7 +24,8 @@ pagespeed:
   - ImageAddDimensions
   - RemoveComments
   url_blacklist:
-  - http://*/assets/images/nodeDemo.gif
+  - http://*/casestudies/technitone/assets/images/nodeDemo.gif
+  - https://*/casestudies/technitone/assets/images/nodeDemo.gif
 
 default_expiration: "30d"
 


### PR DESCRIPTION
fixes #186

we dont want this: http://www.html5rocks.com/en/tutorials/casestudies/technitone/assets/images/nodeDemo.gif

to be this: http://1-ps.googleusercontent.com/x/s.html5rocks-hrd.appspot.com/www.html5rocks.com/en/tutorials/casestudies/technitone/assets/images/wnodeDemo.gif.pagespeed.ic.q919njhKUG.png

ref: https://developers.google.com/appengine/docs/python/config/appconfig#pagespeed
