### PR TITLE
Remove translateZ(0) suggestion from HTML5 speed article.

### DIFF
--- a/content/tutorials/speed/html5/en/index.html
+++ b/content/tutorials/speed/html5/en/index.html
@@ -5,9 +5,7 @@
 {% block headtitle %}Improving the Performance of your HTML5 App{% endblock %}
 {% block pagetitle %}Improving the Performance of your HTML5 App{% endblock %}
 {% block head %}
-<style>
-.hwaccel {  -webkit-transform: translateZ(0); -o-transform: translateZ(0); -moz-transform: translateZ(0); transform: translateZ(0); } /* our favorite trick */
-</style>
+
 {% endblock %}
 {% block pagebreadcrumb %}Improving the Performance of your HTML5 App{% endblock %}
 {% block date %}February 14, 2011{% endblock %}
@@ -112,21 +110,7 @@ HTML5 gives us great tools to enhance the visual appearance of web applications.
 <p>
   How the browser implements this animation is completely hidden from the developer. This in turn means that the browser is able to apply tricks such as GPU acceleration to achieve the defined goal.
 </p>
-<h4>
-  The magic CSS bullet
-</h4>
-<p>
-  Currently most browsers only use GPU acceleration when they have a strong indication that an HTML element would benefit from it. The strongest indication is that a 3D transformation was applied to it. Now you might not really want to apply a 3D transformation, but still gain the benefits from GPU acceleration - no problem. Simply apply the identity transformation:
-</p>
-<p>
-  <code>-webkit-transform: translateZ(0);</code>
-</p>
-<p>
-  Please be warned that this applying this transformation does not guarantee to help your performance. It might simply crank up your GPU, use up more battery but deliver the same performance as before. So be careful with this technique and only use it if you experience a true performance win.
-</p>
-<p>
-  When you think about which element to apply the transformation, go for those that represent a good logical chunk of your page. Ideally this is the element that you are animating and it doesn't contain other elements that you move around.
-</p>
+
 <p>
   There are two useful command-line flags for Chrome to help debugging GPU acceleration:
 </p>


### PR DESCRIPTION
It's deprecated advice.

cc @paullewis
