### PR TITLE
Update content/tutorials/developertools/sourcemaps/en/index.html

### DIFF
--- a/content/tutorials/developertools/sourcemaps/en/index.html
+++ b/content/tutorials/developertools/sourcemaps/en/index.html
@@ -278,6 +278,10 @@ V    V
 
 <p>This of course is a solvable problem and with more attention on source maps we can start seeing some amazing features and better stability.</p>
 
+<h2 id="toc-issues" class="subtitle02">Issues</h2>
+
+<p>Recently <a href="http://blog.jquery.com/2013/01/15/jquery-1-9-final-jquery-2-0-beta-migrate-final-released/">jQuery 1.9</a> added support for source maps when served off of offical CDNs. It also pointed a <a href="http://bugs.jquery.com/ticket/13274#comment:6">peculiar bug</a> when IE conditional compilation comments (//@cc_on) are used before jQuery loads. There has since been a <a href="https://github.com/jquery/jquery/commit/487b703521e63188102c73e8ce6ce203d28f260b">commit</a> to mitigate this by wrapping the sourceMappingURL in a multi-line comment. Lesson to be learned don't use conditional comment.</p>
+
 <h2 id="toc-tools" class="subtitle02">Tools and resource</h2>
 
 <p>Here's some further resources and tools you should check out:</p>


### PR DESCRIPTION
Added additional information about IE conditional compilation comments causing an error in IE. Fixes #278.
