### PR TITLE
Fixed stretched figure images

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -2597,6 +2597,7 @@ ul.figures li a img
 {
   float: left;
   max-width: 150px;
+  height: auto;
   border: 1px solid #eee;
 }
 


### PR DESCRIPTION
Some of the figure images are larger than the 150px space allotted them, and while we constrain their width with a CSS max-width, we're also setting their width and height attributes on the img tag to their native width and height. The result is a stretched aspect ratio. You can see this clearly at http://www.html5rocks.com/en/features/storage.

This patch fixes the issue by adding a height: auto to the CSS rule that contains the max-width.
