### PR TITLE
Set max-width:100% for .page on print

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3240,6 +3240,7 @@ section.disqus
   tr, img { page-break-inside: avoid; }
   img { max-width: 100% !important; }
   @page { margin: 0.5cm; }
+  .page { max-width: 100% }
   p, h2, h3 { orphans: 3; widows: 3; }
   h2, h3 { page-break-after: avoid; }
 


### PR DESCRIPTION
Without this some tutorials can not be printed without cutting off text and especially code samples.
![ss](https://f.cloud.github.com/assets/523154/184459/6ecc9e3e-7cdc-11e2-8579-47b09b7f046c.png)

Also, this issue should be updated:
https://github.com/html5rocks/www.html5rocks.com/issues/15

I don't think a license agreement is really necessary for this tiny change.
