### PR TITLE
less uppercase everywhere makes for easier reading.

### DIFF
--- a/content/profiles.html
+++ b/content/profiles.html
@@ -65,7 +65,7 @@
       <article class="profile one_third" id="{{profile.id}}" itemscope itemtype="http://microformats.org/profile/hcard">
         <section class="pattern-bg-lighter">
           <img itemprop="photo" alt="{{profile.given_name}} {{profile.family_name}}" title="{{profile.given_name}} {{profile.family_name}}" src="/static/images/profiles/75/{{profile.id}}.75.png">
-          <hgroup>
+
             <h2>
               <div itemprop="fn">
                 <div itemprop="n" itemscope>
@@ -83,7 +83,7 @@
               {% if profile.state %}<span itemprop="state">{{profile.state}},</span>{% endif %}
               {% if profile.country %}<span itemprop="country-name">{{profile.country}}</span>{% endif %}
             </h3>
-          </hgroup>
+
           <ul class="urls">
             {% if profile.homepage %}
             <li><a data-type="homepage" itemprop="url" href="{{profile.homepage}}" target="_blank">&nbsp;</a></li>

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -413,9 +413,9 @@ h5
   line-height: 1.125;
 }
 
-h1,
-h2,
-h3
+hgroup h1,
+hgroup h2,
+hgroup h3
 {
   text-transform: uppercase;
 }
@@ -448,7 +448,8 @@ h3
 }
 
 h2:first-child,
-h3:first-child
+h3:first-child,
+.profile h2
 {
   margin: 0 0 .5em;
 }
@@ -2905,7 +2906,6 @@ header.tutorial section
   text-transform: none;
 }
 header.tutorial section h2 {
-  text-transform: uppercase;
   font-size: 26px;
   font-weight: 300;
   margin: 0 0 .25em;
@@ -4125,3 +4125,4 @@ section.disqus
     display: none;
   }
 }
+k


### PR DESCRIPTION
## Masthead before:

![](http://paulirish.com/i/ee6730.png)
## Masthead after:

![](http://paulirish.com/i/825180.png)
## Headlines before:

![](http://paulirish.com/i/680210.png)
## Headlines after:

![](http://paulirish.com/i/dbc830.png)
## Authors before:

![](http://paulirish.com/i/a5af90.png)
## Authors after:

![](http://paulirish.com/i/b746c0.png)

<hr>

I think this dramatically improves the readability of the content.
