### PR TITLE
Fixed incorrect definition of radians

### DIFF
--- a/content/tutorials/webgl/webgl_transforms/en/index.html
+++ b/content/tutorials/webgl/webgl_transforms/en/index.html
@@ -298,7 +298,7 @@ Radians are a unit of measurement used with circles, rotation and angles. Just l
 You're probably aware that math with metric measurements is easier than math with imperial measurements. To go from inches to feet we divide by 12. To go from inches to yards we divide by 36. I don't know about you but I can't divide by 36 in my head. With metric it's much easier. To go from millimeters to centimeters we divide by 10. To from millimeters to meters we divide by 1000. I **can** divide by 1000 in my head.
 </p>
 <p>
-Radians vs degrees are similar. Degrees make the math hard. Radians make the math easy. There are 360 degrees in a circle but there are only 2 radians. So a full turn is 2 radians. A half turn is 1 radian. A 1/4 turn, ie 90 degress is 1/2 radian. A radian is equal to PI (π). So if you want to rotate something 90 degrees just use <code>Math.PI * 0.5</code>. If you want to rotate it 45 degrees use <code>Math.PI * 0.25</code> etc.
+Radians vs degrees are similar. Degrees make the math hard. Radians make the math easy. There are 360 degrees in a circle but there are only 2π radians. So a full turn is 2π radians. A half turn is π radians. A 1/4 turn, ie 90 degress is π/2 radian. So if you want to rotate something 90 degrees just use <code>Math.PI * 0.5</code>. If you want to rotate it 45 degrees use <code>Math.PI * 0.25</code> etc.
 </p>
 <p>
 Nearly all math involving angles, circles or rotation works very simply if you start thinking in radians. So give it try. Use radians, not degrees except in UI displays.


### PR DESCRIPTION
The webgl transforms document attempts to give insight into why radians are valuable, but the mathematical definition of the unit is incorrect. Just cleaning up. Also removed the line stating that a radian is equal to π. This is equivalent to saying that a mile is equal to 4.
