### PR TITLE
Fix GitHub links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **Interested in contributing? Help us:**
 
-- [Localize content](/html5rocks/www.html5rocks.com/wiki/Localization-Guide)
-- [File or fix bugs](/html5rocks/www.html5rocks.com/issues)
-- [Author an article, tutorial, or case study](/html5rocks/www.html5rocks.com/wiki/Contributors-Guide)
+- [Localize content](https://github.com/html5rocks/www.html5rocks.com/wiki/Localization-Guide)
+- [File or fix bugs](https://github.com/html5rocks/www.html5rocks.com/issues)
+- [Author an article, tutorial, or case study](https://github.com/html5rocks/www.html5rocks.com/wiki/Contributors-Guide)
 
-[![HTML5Rocks Screenshot](/html5rocks/www.html5rocks.com/raw/master/static/images/screenshots/landing_page.png)](http://www.html5rocks.com)
+[![HTML5Rocks Screenshot](https://github.com/html5rocks/www.html5rocks.com/raw/master/static/images/screenshots/landing_page.png)](http://www.html5rocks.com)
 
 *HTML5Rocks is by [Google](https://github.com/google)*


### PR DESCRIPTION
I guess these used to work and broke when GitHub change how they render URLs inside the readme?
