### PR TITLE
getUserMedia: suggest Modernizr for detection and use.

### DIFF
--- a/content/tutorials/getusermedia/intro/en/index.md
+++ b/content/tutorials/getusermedia/intro/en/index.md
@@ -131,6 +131,14 @@ Feature detecting is a simple check for the existence of `navigator.getUserMedia
       alert('getUserMedia() is not supported in your browser');
     }
 
+You can also [use Modernizr](http://modernizr.com/) to detect `getUserMedia` to avoid the vendor prefix dance yourself:
+
+    if (Modernizr.getusermedia){
+      var gUM = Modernizr.prefixed('getUserMedia', navigator);
+      gUM({video: true}, function( //...
+      //...
+    }
+
 <h3 id="toc-acccess">Gaining access to an input device</h3>
 
 To use the webcam or microphone, we need to request permission.


### PR DESCRIPTION
This improves likelihood the that detect will continue to work. (e.g. Dolphin's gUM is blacklisted as it doesn't work)

And it's easier to use than asking for all the various prefixes. Seems good.
