### PR TITLE
Added -khtml-user-drag and -webkit-user-drag styles to DnD article for old WebKit support

### DIFF
--- a/content/tutorials/dnd/basics/de/index.html
+++ b/content/tutorials/dnd/basics/de/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">Dragging-Eigenschaften</h3>
 
   <p><code>dataTransfer</code> stellt Eigenschaften für ein visuelles Feedback an den Nutzer während des Drag-Vorgangs bereit. Mit diesen Eigenschaften lässt sich außerdem steuern, wie jedes Drop-Ziel auf einen bestimmten Datentyp reagiert.</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>Beschränkt, welche Art von Drag-Vorgang der Nutzer für das Element ausführen kann. Diese Eigenschaft wird im Drag &amp; Drop-Verarbeitungsmodell verwendet, um <code>dropEffect</code> während der <code>dragenter</code>- und <code>dragover</code>-Ereignisse zu initialisieren. Sie kann auf folgende Werte eingestellt werden: <code>none</code>, <code>copy</code>, <code>copyLink</code>, <code>copyMove</code>, <code>link</code>, <code>linkMove</code>, <code>move</code>, <code>all</code> und <code>uninitialized</code>.
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd>Steuert das Feedback, das der Nutzer während der <code>dragenter</code>- und <code>dragover</code>-Ereignisse erhält. Wenn der Nutzer die Maus über ein Zielelement bewegt, zeigt der Cursor des Browsers an, welche Art von Vorgang stattfinden wird, beispielsweise ein Kopiervorgang, eine Verschiebung und so weiter. Der Effekt kann einen der folgenden Werte annehmen: <code>none</code>, <code>copy</code>, <code>link</code> und <code>move</code>.
     </dd>
     <dt><code>e.dataTransfer.setDragImage(img element, x, y)</code></dt>
-    <dd>Statt des standardmäßigen Doppelbilds des Browsers können Sie optional ein Ziehsymbol als Feedback festlegen: 
+    <dd>Statt des standardmäßigen Doppelbilds des Browsers können Sie optional ein Ziehsymbol als Feedback festlegen:
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">Fazit</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">Referenzen</h2>
   <ul>
-    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag &amp; Drop</a>-Spezifikation</li> 
+    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag &amp; Drop</a>-Spezifikation</li>
     <li><a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">Drag Operations</a> (Drag-Vorgänge) von MDN (Mozilla Developer Network)</li>
     <li>"<a href="http://html5doctor.com/native-drag-and-drop/">Native Drag and Drop</a>" (Natives Drag &amp; Drop), Artikel von HTML5 Doctor</li>
     <li>"<a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a>" (Dateien wie Google Mail herausziehen) im CSS-Ninja</li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/en/index.html
+++ b/content/tutorials/dnd/basics/en/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -165,6 +168,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -451,7 +457,7 @@ function handleDrop(e) {
   <p>The <code>dataTransfer</code> object exposes properties to provide
   visual feedback to the user during the drag process. These properties can also
   be used to control how each drop target responds to a particular data type.</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>Restricts what 'type of drag' the user can perform on the element. It is used in the
@@ -468,7 +474,7 @@ function handleDrop(e) {
     </dd>
     <dt><code>e.dataTransfer.setDragImage(imgElement, x, y)</code></dt>
     <dd>Instead of using the browser's default 'ghost image' feedback, you can optionally set a drag
-    icon 
+    icon
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -514,7 +520,7 @@ function handleDrop(e) {
 
   <h3 id="toc-desktop-dnd-out">Drag-out: dragging from the browser to the desktop</h3>
 
-  <p>For a complete guide to dragging files from the browser to the desktop, see 
+  <p>For a complete guide to dragging files from the browser to the desktop, see
   <a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a> from the CSS Ninja.</p>
 
   <h2 id="toc-examples">Examples</h2>
@@ -533,9 +539,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">Conclusion</h2>
@@ -549,7 +555,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">References</h2>
   <ul>
-    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a> specification</li> 
+    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a> specification</li>
     <li><a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">Drag Operations</a> from MDC</li>
     <li><a href="http://html5doctor.com/native-drag-and-drop/">Native Drag and Drop</a> article from html5doctor</li>
     <li><a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a> from the CSS Ninja</li>
@@ -716,9 +722,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -789,7 +795,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/es/index.html
+++ b/content/tutorials/dnd/basics/es/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">Propiedades de arrastre</h3>
 
   <p><code>dataTransfer</code> expone una serie de propiedades para ofrecer señales visuales al usuario durante el proceso de arrastre. Estas propiedades también se pueden utilizar para controlar la respuesta de cada elemento de destino de la operación de arrastre a un determinado tipo de datos.</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>Restringe el "tipo de arrastre" que puede realizar el usuario en el elemento. Se utiliza en el modelo de procesamiento de la operación de arrastrar y soltar para la inicialización de <code>dropEffect</code> durante los eventos <code>dragenter</code> y <code>dragover</code>. Esta propiedad admite los siguientes valores: <code>none</code>, <code>copy</code>, <code>copyLink</code>, <code>copyMove</code>, <code>link</code>, <code>linkMove</code>, <code>move</code>, <code>all</code> y <code>uninitialized</code>.
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd>Controla la información que recibe el usuario durante los eventos <code>dragenter</code> y <code>dragover</code>. Cuando el usuario coloca el ratón sobre un elemento de destino, el cursor del navegador indica el tipo de operación que se va a realizar (por ejemplo, una operación de copia, un movimiento, etc.). La propiedad de efecto admite los siguientes valores: <code>none</code>, <code>copy</code>, <code>link</code> y <code>move</code>.
     </dd>
     <dt><code>e.dataTransfer.setDragImage(img element, x, y)</code></dt>
-    <dd>En lugar de utilizar la información predeterminada del navegador (la "imagen fantasma"), puedes establecer un icono de arrastre. 
+    <dd>En lugar de utilizar la información predeterminada del navegador (la "imagen fantasma"), puedes establecer un icono de arrastre.
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">Conclusión</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">Referencias</h2>
   <ul>
-    <li>Especificación de la función de arrastrar y soltar (<a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a>)</li> 
+    <li>Especificación de la función de arrastrar y soltar (<a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a>)</li>
     <li>Artículo sobre operaciones de arrastre (<a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">Drag Operations</a>) de MDN</li>
     <li>Artículo sobre la función nativa de arrastrar y soltar (<a href="http://html5doctor.com/native-drag-and-drop/">Native Drag and Drop</a>) de HTML5 Doctor</li>
     <li>Artículo sobre arrastre de archivos como en Gmail (<a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a>) de CSS Ninja</li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/ja/index.html
+++ b/content/tutorials/dnd/basics/ja/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">ドラッグのプロパティ</h3>
 
   <p><code>dataTransfer</code> には、ドラッグ プロセス中に視覚的なフィードバックをユーザーに提供するためのプロパティがあります。これらのプロパティを使用して、各ドロップ ターゲットが特定のデータ型にどのように応答するかを制御することもできます。</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>要素に対してユーザーが実行できる「ドラッグの種類」を制限します。これは、ドラッグ＆ドロップ プロセス モデルにおいて <code>dragenter</code> および <code>dragover</code> イベント中に <code>dropEffect</code> を初期化するために使用されます。このプロパティの値は、<code>none</code>、<code>copy</code>、<code>copyLink</code>、<code>copyMove</code>、<code>link</code>、<code>linkMove</code>、<code>move</code>、<code>all</code>、<code>uninitialized</code> に設定できます。
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd><code>dragenter</code> および <code>dragover</code> イベント中にユーザーに与えるフィードバックを制御します。ユーザーがターゲット要素にカーソルを移動すると、ブラウザのカーソルは実行する操作（コピー、移動など）の種類を示す形に変わります。この効果では、<code>none</code>、<code>copy</code>、<code>link</code>、<code>move</code> のいずれかの値を処理できます。
     </dd>
     <dt><code>e.dataTransfer.setDragImage(img element, x, y)</code></dt>
-    <dd>ブラウザのデフォルトの「ゴースト画像」フィードバックを使用する代わりに、ドラッグ アイコンを設定することもできます。 
+    <dd>ブラウザのデフォルトの「ゴースト画像」フィードバックを使用する代わりに、ドラッグ アイコンを設定することもできます。
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">まとめ</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">参考資料</h2>
   <ul>
-    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">ドラッグ＆ドロップ</a>仕様</li> 
+    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">ドラッグ＆ドロップ</a>仕様</li>
     <li>MDC の<a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">ドラッグ操作</a></li>
     <li>html5doctor の <a href="http://html5doctor.com/native-drag-and-drop/">Native Drag and Drop</a> の記事</li>
     <li>CSS Ninja の <a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a></li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/pt/index.html
+++ b/content/tutorials/dnd/basics/pt/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">Como arrastar propriedades</h3>
 
   <p><code>dataTransfer</code> exibe propriedades para fornecer uma resposta visual ao usuário durante o processo de arraste. Essas propriedades também podem ser usadas para controlar a forma como o destino da ação de soltar responde a um tipo específico de dados.</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>Restringe o tipo de ação de arrastar que o usuário pode executar no elemento. É usado no modelo de processamento de arrastar e soltar para inicializar o <code>dropEffect</code> durante os eventos <code>dragenter</code> e <code>dragover</code>. A propriedade pode ser definida com os seguintes valores: <code>none</code>, <code>copy</code>, <code>copyLink</code>, <code>copyMove</code>, <code>link</code>, <code>linkMove</code>, <code>move</code>, <code>all</code> e <code>uninitialized</code>.
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd>Controla o feedback que o usuário recebe durante os eventos <code>dragenter</code> e <code>dragover</code>. Quando o usuário passa o mouse sobre um elemento de destino, o cursor do navegador indica o tipo de operação que vai ocorrer (por exemplo, copiar, mover, etc.). O efeito pode assumir um dos seguintes valores: <code>none</code>, <code>copy</code>, <code>link</code>, <code>move</code>.
     </dd>
     <dt><code>e.dataTransfer.setDragImage(elemento img, x, y)</code></dt>
-    <dd>Em vez de usar a resposta de "imagem fantasma" padrão do navegador, você pode também definir um ícone de arraste 
+    <dd>Em vez de usar a resposta de "imagem fantasma" padrão do navegador, você pode também definir um ícone de arraste
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">Conclusão</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">Referências</h2>
   <ul>
-    <li>Especificação <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a></li> 
+    <li>Especificação <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Drag and Drop</a></li>
     <li><a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">Drag Operations</a> (Operações de arraste) no MDC</li>
     <li>Artigo "<a href="http://html5doctor.com/native-drag-and-drop/">Native Drag and Drop</a>" (Arrastar e soltar nativo) do html5doctor</li>
     <li>"<a href="http://www.thecssninja.com/javascript/gmail-dragout">Drag out files like Gmail</a>" (Arrastar arquivos para outro local como no Gmail) do CSS Ninja</li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/ru/index.html
+++ b/content/tutorials/dnd/basics/ru/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">Свойства перетаскивания</h3>
 
   <p>Объект <code>dataTransfer</code> обладает свойствами, которые создают визуальную подсказку для пользователей в процессе перетаскивания. Их также можно использовать для управления реакцией каждой цели перетаскивания на определенный тип данных.</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>Ограничивает "тип перетаскивания", которое пользователь может выполнять с элементом. Это свойство используется в модели обработки перетаскивания для инициализации объекта <code>dropEffect</code> во время событий <code>dragenter</code> и <code>dragover</code>. Это свойства может принимать следующие значения: <code>none</code>, <code>copy</code>, <code>copyLink</code>, <code>copyMove</code>, <code>link</code>, <code>linkMove</code>, <code>move</code>, <code>all</code> и <code>uninitialized</code>.
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd>Управляет реакцией, которую пользователь получает во время событий <code>dragenter</code> и <code>dragover</code>. Когда перетаскиваемый объект наводится на целевой элемент, указатель браузера принимает вид, соответствующий типу предполагаемой операции (например, копирование, перенос и т. д.). Свойство может принимать следующие значения: <code>none</code>, <code>copy</code>, <code>link</code>, <code>move</code>.
     </dd>
     <dt><code>e.dataTransfer.setDragImage(img element, x, y)</code></dt>
-    <dd>Вместо использования "фантомного изображения", которое браузер создает по умолчанию, можно задать значок перетаскивания. 
+    <dd>Вместо использования "фантомного изображения", которое браузер создает по умолчанию, можно задать значок перетаскивания.
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">Заключение</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">Ссылки</h2>
   <ul>
-    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Перетаскивание</a> – спецификация</li> 
+    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">Перетаскивание</a> – спецификация</li>
     <li><a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">Операции перетаскивания</a> из MDC</li>
     <li>Статья <a href="http://html5doctor.com/native-drag-and-drop/">Встроенная функция перетаскивания</a> на веб-сайте html5doctor</li>
     <li><a href="http://www.thecssninja.com/javascript/gmail-dragout">Перетаскивание файлов как из Gmail</a> на веб-сайте CSS Ninja</li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;

--- a/content/tutorials/dnd/basics/zh/index.html
+++ b/content/tutorials/dnd/basics/zh/index.html
@@ -10,6 +10,9 @@ h1,h2,h3,h4 { clear: both; }
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 dd {
   padding: 5px 0;
@@ -145,6 +148,9 @@ if (Modernizr.draganddrop) {
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;
 }
 .column {
   height: 150px;
@@ -393,7 +399,7 @@ function handleDrop(e) {
   <h3 id="toc-drag-properties">拖动属性</h3>
 
   <p><code>dataTransfer</code> 使用的属性在拖动过程中为用户提供了可视化反馈。这些属性还可用于控制每个放置目标响应特定数据类型的方式。</p>
-  
+
   <dl>
     <dt><code>dataTransfer.effectAllowed</code></dt>
     <dd>限制用户可在元素上执行的“拖动类型”。在拖放处理模型中用于初始化 <code>dragenter</code> 和 <code>dragover</code> 事件中的 <code>dropEffect</code>。该属性可设置为以下值：<code>none</code>、<code>copy</code>、<code>copyLink</code>、<code>copyMove</code>、<code>link</code>、<code>linkMove</code>、<code>move</code>、<code>all</code> 和 <code>uninitialized</code>。
@@ -402,7 +408,7 @@ function handleDrop(e) {
     <dd>控制用户在 <code>dragenter</code> 和 <code>dragover</code> 事件期间收到的反馈。当用户将鼠标悬停在目标元素上方时，浏览器的光标会显示即将采取的操作类型（例如复制、移动等）。结果可能呈现为以下某个值：<code>none</code>、<code>copy</code>、<code>link</code>、<code>move</code>。
     </dd>
     <dt><code>e.dataTransfer.setDragImage(img element, x, y)</code></dt>
-    <dd>除了使用浏览器默认的“重像”反馈外，您也可以选择设置拖动图标 
+    <dd>除了使用浏览器默认的“重像”反馈外，您也可以选择设置拖动图标
 <pre class="prettyprint">
 var dragIcon = document.createElement('img');
 dragIcon.src = 'logo.png';
@@ -457,9 +463,9 @@ function handleDrop(e) {
 
 <!--
   other examples:
-  <li>Rearrange list</li> 
-  <li>Creating an image gallery</li> 
-  <li>Exporting a canvas image</li> 
+  <li>Rearrange list</li>
+  <li>Creating an image gallery</li>
+  <li>Exporting a canvas image</li>
 -->
 
   <h2 id="toc-conclusion">总结</h2>
@@ -468,7 +474,7 @@ function handleDrop(e) {
 
   <h2 id="toc-references">参考</h2>
   <ul>
-    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">拖放</a>规范</li> 
+    <li><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dnd">拖放</a>规范</li>
     <li>MDC <a href="https://developer.mozilla.org/En/DragDrop/Drag_Operations">拖动操作</a></li>
     <li>html5doctor 上的“<a href="http://html5doctor.com/native-drag-and-drop/">本机拖放</a>”文章</li>
     <li>CSS 帮助资料中的“<a href="http://www.thecssninja.com/javascript/gmail-dragout">拖出文件（如 Gmail）</a>”</li>
@@ -635,9 +641,9 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
-    
+
     return false;
   };
 
@@ -708,7 +714,7 @@ var samples = samples || {};
     if (e.preventDefault) {
       e.preventDefault(); // Allows us to drop.
     }
-  
+
     e.dataTransfer.dropEffect = 'move';
 
     return false;


### PR DESCRIPTION
Safari 4 and earlier don't support the `draggable` attribute, but `-khtml-user-drag: element` / `-webkit-user-drag: element` have the same effect.

This isn't just necromancy; `Modernizr.draganddrop` returns `true` for these browsers, so with the article recommending this as the method for feature detection, a developer could leave users with a broken interface without these styles.

(Any other changes in the diff are because of trailing whitespace trimming by my text editor)
