### PR TITLE
Bad tag closing fix

### DIFF
--- a/content/tutorials/masking/adobe/it/index.html
+++ b/content/tutorials/masking/adobe/it/index.html
@@ -183,7 +183,7 @@
 <li><code>rectangle(&lt;top&gt;, &lt;left&gt;, &lt;width&gt;,
     &lt;height&gt;, &lt;rx&gt;, &lt;ry&gt;)</code> definisce un
     rettangolo, in maniera simile alla funzione <code>rect()</code> di
-    <code>clip</clip>, e aggiunge due parametri opzionali per
+    <code>clip</code>, e aggiunge due parametri opzionali per
     i <a href="http://www.folklore.org/StoryView.py?story=Round_Rects_Are_Everywhere.txt">bordi arrotondati</a>.</li>
 <li><code>circle(&lt;cx&gt;, &lt;cy&gt;, &lt;r&gt;)</code> definisce
   una semplice circonferenza con un centro e un raggio.</li>


### PR DESCRIPTION
A `code` tag was closed with `</clip>` in my italian translation of CSS Masking tutorial.
I swear, no more Jack during work time after this.
