### PR TITLE
Fixes #402 - stops loading all the articles into memory on the index page

### DIFF
--- a/main.py
+++ b/main.py
@@ -408,7 +408,11 @@ class ContentHandler(webapp2.RequestHandler):
         results = TagsHandler().get_as_db(
             relpath, limit=self.FEATURE_PAGE_WHATS_NEW_LIMIT)
       else:
-        results = models.Resource.get_all(order='-publication_date')
+        if relpath == '':
+          resource_limit = 10
+        else:
+          resource_limit = None
+        results = models.Resource.get_all(order='-publication_date', limit=resource_limit)
 
       tutorials = [] # List of final result set.
       authors = [] # List of authors related to the result set.

--- a/models.py
+++ b/models.py
@@ -91,7 +91,7 @@ class Resource(DictModel):
   @classmethod
   def get_all(self, order=None, limit=None, qfilter=None):
     limit = limit or settings.MAX_FETCH_LIMIT
-
+    print "LIMIT: %s" % limit
     key = '%s|tutorials' % (settings.MEMCACHE_KEY_PREFIX,)
 
     if order is not None:


### PR DESCRIPTION
I belive this was causing a huge amount of slow down.  Now only gets 10 articles for the index page.  All the rest of the pages where this was used uses the original limit of 1000 where applicable
