### PR TITLE
Fixes #417 - removes html5 badge from article templates

### DIFF
--- a/templates/tutorial.html
+++ b/templates/tutorial.html
@@ -37,16 +37,6 @@
         </div>
       </section>
 
-      {% if not is_mobile %}
-      <aside id="html5badge">
-        <a href="http://www.w3.org/html/logo/">
-        {% block html5badge %}
-        <img src="/static/images/identity/html5-badge-h-solo.png" width="63" height="64" alt="{% trans "HTML5 Powered" %}" title="{% trans "HTML5 Powered" %}" style="margin-right:17px" />
-        {% endblock %}
-        </a>
-      </aside>
-      {% endif %}
-
       <section class="browser_support">
           <h3>{% trans "Supported browsers:" %}</h3>
           <span class="browsers">


### PR DESCRIPTION
Its not visible on mobile, and it takes up space and resources on desktop.
