### PR TITLE
Fixes #385 - New ToC for mobile

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3760,17 +3760,45 @@ section.disqus
     box-sizing: border-box;
   }
   
-  article.tutorial .outline_nav_toggle.activated a {
+  article.tutorial .outline_nav_toggle.activated ul a {
     color: #ddd;
     margin: 0;
   }
   
-  article.tutorial .outline_nav_toggle.activated a:active {
+  article.tutorial .outline_nav_toggle.activated ul a:active {
     color: #ddd;
   }
   
-  article.tutorial .outline_nav_toggle.activated a:visited {
+  article.tutorial .outline_nav_toggle.activated ul a:visited {
     color: #ddd;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul a {
+    color: #bbb;
+    color: #bbb !important;
+    margin: 0;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul  a:active {
+    color: #bbb;
+    color: #bbb !important;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul ul a:visited {
+    color: #bbb !important;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul ul a {
+    color: #999 !important;
+    margin: 0;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul ul a:active {
+    color: #999 !important;
+  }
+  
+  article.tutorial .outline_nav_toggle.activated ul ul ul a:visited {
+    color: #999 !important;
   }
   
   article.tutorial nav {


### PR DESCRIPTION
we lack vertical space on mobile and the ToC in most articles takes up at least one or two screens.  This PR will push the ToC to the footer of the device and only show when the user clicks on it.

This is how it now looks.
![screen shot 2013-06-20 at 4 48 35 pm](https://f.cloud.github.com/assets/45510/683134/afeeb2d6-d9d8-11e2-93b0-c3875b8c46ec.png)

and when expanded

![screen shot 2013-06-20 at 4 48 44 pm](https://f.cloud.github.com/assets/45510/682153/3933663a-d9c1-11e2-8cc1-0dac02f79f52.png)
