### PR TITLE
Update to terminology around flag enabling

### DIFF
--- a/content/tutorials/casestudies/natgeo/en/index.html
+++ b/content/tutorials/casestudies/natgeo/en/index.html
@@ -141,7 +141,7 @@ CSS custom filters enable interesting effects like page wrapping that looks like
 
 <h2 id="toc-pre-render">Pre-Render Textures in WebGL</h2>
 <p>
-The jewel of this article was the first complete image of ‘The President’, believed to be the world’s second tallest tree and the largest by mass. This image was created by photo-stitching hundreds of photos of the tree to create a full picture.  We wanted to simulate this process by breaking the image into a bunch of little photos that fly into place to create the full picture.  This was achieved using WebGL, specifically with the <a href="http://threejs.org/">Three.js library</a>, which is a higher level API wrapper around WebGL.
+The jewel of this article was the first complete image of ‘The President’, believed to be the second largest tree in the world by volume. This image was created by photo-stitching hundreds of photos of the tree to create a full picture.  We wanted to simulate this process by breaking the image into a bunch of little photos that fly into place to create the full picture.  This was achieved using WebGL, specifically with the <a href="http://threejs.org/">Three.js library</a>, which is a higher level API wrapper around WebGL.
 </p>
 <p>
   <figure>
@@ -171,7 +171,7 @@ Here you can see we’re using a variable for the x and y offset of the texture.
 Because some of the features the demo uses are still experimental, the article needs to be viewed in <a href="https://www.google.com/intl/en/chrome/browser/canary.html">Chrome Canary</a> with the following runtime flags enabled:
 </p>
 <ul>
-<li>Experimental Blink features</li>
+<li>Enable experimental Web Platform features</li>
 <li>CSS Shaders</li>
 <li>Disable accelerated 2D canvas*</li>
 </ul>


### PR DESCRIPTION
Blink updated the name of the flag used for experimental 'Web Platform' features.
