### PR TITLE
Base.css needs slightly better print styles

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3061,6 +3061,8 @@ section.disqus
   pre .tag, code .tag { color: #006; font-weight: bold; }
   pre .atn, code .atn { color: #404; }
   pre .atv, code .atv { color: #060; }
+
+  .page header .share, nav, header hgroup, a.disqus_comments { display:none !important;}
 }
 
 


### PR DESCRIPTION
This hides some unneeded elements to print.

@paulkinlan is also looking into moving the MQs back to 'all' instead of screen.
Ideally the printed page gets the <1000px styles.
