### PR TITLE
Fix a KeyError when there's no User-Agent header field

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,11 +62,13 @@ class ContentHandler(webapp2.RequestHandler):
     translation.activate( self.locale )
 
   def browser(self):
-    return str(self.request.headers['User-Agent'])
+    """Returns a string representing the user agent, or None."""
+    return self.request.headers.get('User-Agent')
 
   def is_awesome_mobile_device(self):
+    """Returns True if the browser is a string indicating an awesome device."""
     browser = self.browser()
-    return browser.find('Android') != -1 or browser.find('iPhone') != -1
+    return browser and (browser.find('Android') != -1 or browser.find('iPhone') != -1)
 
   def get_toc(self, path):
     # Only have TOC on tutorial pages. Don't do work for others.


### PR DESCRIPTION
I happened to find 500 errors for requests without the User-Agent header field. I apologize that I have not tested this code. I'd appreciate it if anyone could run a test before merging. Thanks.
