### PR TITLE
Omit needless meta and fix HTML5Rocks image

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -51,7 +51,7 @@
   <meta property="og:title" content="{% if tut.title %}{{tut.title|safe}}{% endif %}{% if tut.subtitle %}: {{tut.subtitle|safe}}{% endif %} - {% trans "HTML5 Rocks" %}">
   <meta property="og:url" content="{{canonical_url}}">
   <meta property="og:description" content="{% if tut.description %}{{tut.description|safe}}{% else %}{{description|safe}}{% endif %}">
-  <meta property="og:image" content="{{host}}/static/images/html5rocks-logo-wings.png">
+  <meta property="og:image" content="{% if tut.author %}{{host}}/static/images/profiles/{{ tut.author.key.name }}.png{% else %}{{host}}/static/images/html5rocks-logo-wings.png{% endif %}">
   <meta property="og:site_name" content="{% trans "HTML5 Rocks" %} - {% trans "A resource for open web HTML5 developers" %}">
   {% endif %}
 


### PR DESCRIPTION
Fix for HTML5Rocks image on Twitter Cards, OGP.
Omit needless Twitter cards meta tag.
