### PR TITLE
Removing outdated information

### DIFF
--- a/content/tutorials/cors/en/index.html
+++ b/content/tutorials/cors/en/index.html
@@ -384,10 +384,6 @@ Its recommended that you don’t set this header unless you are sure you want co
 If you want clients to be able to access other headers, you have to use the <code>Access-Control-Expose-Headers</code> header. The value of this header is a comma-delimited list of response headers you want to expose to the client.
 </p>
 
-<p>
-As of this writing, all browsers have buggy <code>getRequestHeader()</code> implementations, so the headers may not be accessible to clients even after you set the Access-Control-Expose-Headers header. See the <a href="#toc-known-bugs">Known Bugs</a> section below for more details.
-</p>
-
 <h3 id="toc-handling-a-not-so-simple-request">Handling a not-so-simple request</h3>
 
 <p>
@@ -629,9 +625,9 @@ The server doesn't need to include any additional CORS headers or do any more wo
 Known Issues
 </h2>
 <p>
-CORS support is still being actively developed in all browsers; here's a list of known issues (as of 9/21/2012):
+CORS support is still being actively developed in all browsers; here's a list of known issues (as of 10/2/2013):
 <ol>
-<li>XMLHttpRequests' getAllResponseHeaders() doesn't honor Access-Control-Expose-Headers - Firefox doesn't return response headers when calling getAllResponseHeaders(). (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=608735">Firefox bug</a>). A similar <a href="https://bugs.webkit.org/show_bug.cgi?id=41210">bug in WebKit</a> has been fixed.</li>
+<li>FIXED <strike>XMLHttpRequests' getAllResponseHeaders() doesn't honor Access-Control-Expose-Headers - Firefox doesn't return response headers when calling getAllResponseHeaders(). (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=608735">Firefox bug</a>). A similar <a href="https://bugs.webkit.org/show_bug.cgi?id=41210">bug in WebKit</a> has been fixed.</strike></li>
 <li>No error information provided to onerror handler - When the onerror handler is fired, the status code is 0, and there is no statusText. This may be by design, but it can be confusing when trying to debug why CORS requests are failing.</li>
 </ol>
 </p>


### PR DESCRIPTION
The getResponseHeaders() bug has been fixed in all browsers.
