### PR TITLE
Fix cut-off FACT text.

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -2865,6 +2865,10 @@ article.tutorial figure
   text-align: center;
 }
 
+article.tutorial section {
+  overflow: visible; /* Make sure FACT and TIP text isn't cut off */
+}
+
 article.tutorial .notice {
   background: hsla(60, 70%, 92%, 1);
   padding: 4px 10px;


### PR DESCRIPTION
I think this rule is missing from the .fact and .tip styles in base.css. See Pete's new forms article for an example.
