### PR TITLE
Fix title that appears on G+

### DIFF
--- a/templates/v2-base.html
+++ b/templates/v2-base.html
@@ -34,7 +34,7 @@
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="alternate" type="application/rss+xml" title="{% trans "HTML5 Rocks RSS" %}" href="http://feeds.feedburner.com/html5rocks">
 
-  <meta itemprop="name" content="{% trans "HTML5 Rocks" %}">
+  <meta itemprop="name" content="{% if tut.title %}{{tut.title|safe}}{% endif %}{% if tut.subtitle %}: {{tut.subtitle|safe}}{% endif %} - {% trans "HTML5 Rocks" %}">
   <meta itemprop="description" content="{% if tut.description %}{{tut.description|safe}}{% else %}{{description|safe}}{% endif %}">
   {% block share_image %}
   <meta itemprop="image" content="{{host}}/static/images/html5rocks-logo-wings.png">


### PR DESCRIPTION
HTML5Rocks article link on Google+ always show as "HTML5Rocks". This patch will fix microdata itemprop="name" of articles so that G+ can display concrete title.
