### PR TITLE
Translate /tutorials/webcomponents/customelements/ into Simplified Chinese

### DIFF
--- a/content/tutorials/webcomponents/customelements/zh/build.sh
+++ b/content/tutorials/webcomponents/customelements/zh/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Generates the HTML5Rocks template from a markdown file containing content.
+#
+# Author: Boris Smus <smus@html5rocks.com>
+# Modified: Eric Bidelman <ericbidelman@html5rocks.com>
+
+rm index.html
+cat header.html >> index.html
+/usr/local/bin/markdown_py index.md >> index.html
+cat footer.html >> index.html
+
+sed -i -e 's/<pre>/<pre class="prettyprint">/g' index.html
+
+rm index.html-e

--- a/content/tutorials/webcomponents/customelements/zh/footer.html
+++ b/content/tutorials/webcomponents/customelements/zh/footer.html
@@ -1,0 +1,8 @@
+<script>
+document.addEventListener('DOMContentLoaded', function(e) {
+  if (!isCompatible()) {
+    document.body.classList.add('disabledemos');
+  }
+});
+</script>
+{% endblock %}

--- a/content/tutorials/webcomponents/customelements/zh/header.html
+++ b/content/tutorials/webcomponents/customelements/zh/header.html
@@ -1,0 +1,191 @@
+{% extends "tutorial.html" %}
+{% load mixin from templatefilters %}
+
+{% block headtitle %}自定义元素：在 HTML 中定义新元素{% endblock %}
+{% block pagetitle %}自定义元素：在 HTML 中定义新元素{% endblock %}
+{% block pagebreadcrumb %}自定义元素：在 HTML 中定义新元素{% endblock %}
+
+{% block head %}
+<style>
+/*blockquote:not(.talkinghead) {
+  background: rgb(238, 238, 238);
+  padding: 1px 15px;
+  position: relative;
+}
+blockquote:not(.talkinghead):before,
+blockquote:not(.talkinghead):after {
+  font-size: 75px;
+  position: absolute;
+  color: #ccc;
+}
+blockquote:not(.talkinghead):before {
+  content: '“';
+  top: -25px;
+  left: -15px;
+}
+blockquote:not(.talkinghead):after {
+  content: '”';
+  right: -5px;
+  bottom: -55px;
+}*/
+.talkinghead.singleline:before {
+  top: 5px !important;
+}
+button a {
+  color: inherit !important;
+}
+.centered {
+  text-align: center;
+}
+figure img {
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+article.tutorial section {
+  overflow: visible;
+}
+.talkinghead:before {
+  background-image: url(/static/images/profiles/75/ericbidelman.75.png);
+  background-position: 0px 0px !important;
+}
+
+article.tutorial .notice.fact,
+article.tutorial .notice.tip {
+  position: relative;
+  padding-left: 25px;
+}
+article.tutorial .notice.fact:before,
+article.tutorial .notice.tip:before {
+  position: absolute;
+  top: -5px;
+  left: -10px;
+  text-transform: uppercase;
+  -webkit-transform: rotateZ(-30deg);
+  -moz-transform: rotateZ(-30deg);
+  -o-transform: rotateZ(-30deg);
+  -ms-transform: rotateZ(-30deg);
+  transform: rotateZ(-30deg);
+  color: rgb(237, 71, 50);
+  font-weight: bold;
+  content: "Fact";
+}
+article.tutorial .notice.tip {
+  padding-left: 20px;
+}
+article.tutorial .notice.tip:before {
+  content: "Tip";
+  top: -5px;
+  left: -5px;
+}
+
+.tutorial table td,
+.tutorial table th {
+  border: 1px solid #ccc;
+  padding: 5px;
+}
+.tutorial table th {
+  background: #222;
+  color: white;
+  padding: 10px;
+  font-weight: 600;
+}
+.disabledemos .demoarea {
+  display: none !important;
+}
+.demoarea {
+  margin-top: 20px;
+}
+.demoarea {
+  padding: 10px;
+  background: #fff;
+  border: 1px dashed #000;
+  display: inline-block;
+  position: relative;
+}
+.demoarea:before {
+  content: 'Live demo:';
+  position: absolute;
+  top: -30px;
+  left: 0;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+/* Demos */
+app-panel {
+  display: flex;
+  display: -webkit-flex;
+}
+[is="x-item"] {
+  transition: opacity 400ms ease-in-out;
+  opacity: 0.3;
+  background: rgb(255, 0, 255);
+  color: white;
+  flex: 1;
+  -webkit-flex: 1;
+  text-align: center;
+  border-radius: 50%;
+}
+[is="x-item"]:hover {
+  opacity: 1.0;
+}
+app-panel > [is="x-item"] {
+  padding: 5px;
+  list-style: none;
+  margin: 0 7px;
+}
+
+/* apply a dashed border to all unresolved elements */
+x-panel:unresolved {
+  border: 1px dashed red;
+  display: inline-block;
+}
+/* x-panel's that are unresolved are red */
+x-panel:unresolved {
+  color: red;
+}
+/* once the definition of x-panel is registered, it becomes green */
+x-panel {
+  color: green;
+  display: block;
+  padding: 5px;
+}
+
+.kbd {
+  padding: 0.1em 0.6em;
+  border: 1px solid rgb(204, 204, 204);
+  font-size: 11px;
+  font-family: Arial,Helvetica,sans-serif;
+  background-color: rgb(247, 247, 247);
+  color: rgb(51, 51, 51);
+  box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px rgb(255, 255, 255) inset;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0 0.1em;
+  text-shadow: 0 1px 0 rgb(255, 255, 255);
+  line-height: 1.5;
+  white-space: nowrap;
+}
+</style>
+{% endblock %}
+
+{% block iscompatible %}
+  return 'registerElement' in document;
+{% endblock %}
+
+{% block html5badge %}
+<!-- Your HTML5 badge (tech class icons used in the article) goes here -->
+{% endblock %}
+
+{% block share_image %}
+<!--<meta itemprop="image" content="images/your_social_sharing_img.png">-->
+{% endblock %}
+
+{% block translator %}
+<div class="translator">
+  <strong>翻译：</strong> <a href="http://forcefront.com/">米粽 (Leo Deng)</a>
+</div>
+{% endblock %}
+
+{% block content %}
+

--- a/content/tutorials/webcomponents/customelements/zh/index.html
+++ b/content/tutorials/webcomponents/customelements/zh/index.html
@@ -1,0 +1,711 @@
+{% extends "tutorial.html" %}
+{% load mixin from templatefilters %}
+
+{% block headtitle %}自定义元素：在 HTML 中定义新元素{% endblock %}
+{% block pagetitle %}自定义元素：在 HTML 中定义新元素{% endblock %}
+{% block pagebreadcrumb %}自定义元素：在 HTML 中定义新元素{% endblock %}
+
+{% block head %}
+<style>
+/*blockquote:not(.talkinghead) {
+  background: rgb(238, 238, 238);
+  padding: 1px 15px;
+  position: relative;
+}
+blockquote:not(.talkinghead):before,
+blockquote:not(.talkinghead):after {
+  font-size: 75px;
+  position: absolute;
+  color: #ccc;
+}
+blockquote:not(.talkinghead):before {
+  content: '“';
+  top: -25px;
+  left: -15px;
+}
+blockquote:not(.talkinghead):after {
+  content: '”';
+  right: -5px;
+  bottom: -55px;
+}*/
+.talkinghead.singleline:before {
+  top: 5px !important;
+}
+button a {
+  color: inherit !important;
+}
+.centered {
+  text-align: center;
+}
+figure img {
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+article.tutorial section {
+  overflow: visible;
+}
+.talkinghead:before {
+  background-image: url(/static/images/profiles/75/ericbidelman.75.png);
+  background-position: 0px 0px !important;
+}
+
+article.tutorial .notice.fact,
+article.tutorial .notice.tip {
+  position: relative;
+  padding-left: 25px;
+}
+article.tutorial .notice.fact:before,
+article.tutorial .notice.tip:before {
+  position: absolute;
+  top: -5px;
+  left: -10px;
+  text-transform: uppercase;
+  -webkit-transform: rotateZ(-30deg);
+  -moz-transform: rotateZ(-30deg);
+  -o-transform: rotateZ(-30deg);
+  -ms-transform: rotateZ(-30deg);
+  transform: rotateZ(-30deg);
+  color: rgb(237, 71, 50);
+  font-weight: bold;
+  content: "Fact";
+}
+article.tutorial .notice.tip {
+  padding-left: 20px;
+}
+article.tutorial .notice.tip:before {
+  content: "Tip";
+  top: -5px;
+  left: -5px;
+}
+
+.tutorial table td,
+.tutorial table th {
+  border: 1px solid #ccc;
+  padding: 5px;
+}
+.tutorial table th {
+  background: #222;
+  color: white;
+  padding: 10px;
+  font-weight: 600;
+}
+.disabledemos .demoarea {
+  display: none !important;
+}
+.demoarea {
+  margin-top: 20px;
+}
+.demoarea {
+  padding: 10px;
+  background: #fff;
+  border: 1px dashed #000;
+  display: inline-block;
+  position: relative;
+}
+.demoarea:before {
+  content: 'Live demo:';
+  position: absolute;
+  top: -30px;
+  left: 0;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+/* Demos */
+app-panel {
+  display: flex;
+  display: -webkit-flex;
+}
+[is="x-item"] {
+  transition: opacity 400ms ease-in-out;
+  opacity: 0.3;
+  background: rgb(255, 0, 255);
+  color: white;
+  flex: 1;
+  -webkit-flex: 1;
+  text-align: center;
+  border-radius: 50%;
+}
+[is="x-item"]:hover {
+  opacity: 1.0;
+}
+app-panel > [is="x-item"] {
+  padding: 5px;
+  list-style: none;
+  margin: 0 7px;
+}
+
+/* apply a dashed border to all unresolved elements */
+x-panel:unresolved {
+  border: 1px dashed red;
+  display: inline-block;
+}
+/* x-panel's that are unresolved are red */
+x-panel:unresolved {
+  color: red;
+}
+/* once the definition of x-panel is registered, it becomes green */
+x-panel {
+  color: green;
+  display: block;
+  padding: 5px;
+}
+
+.kbd {
+  padding: 0.1em 0.6em;
+  border: 1px solid rgb(204, 204, 204);
+  font-size: 11px;
+  font-family: Arial,Helvetica,sans-serif;
+  background-color: rgb(247, 247, 247);
+  color: rgb(51, 51, 51);
+  box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2),0 0 0 2px rgb(255, 255, 255) inset;
+  border-radius: 3px;
+  display: inline-block;
+  margin: 0 0.1em;
+  text-shadow: 0 1px 0 rgb(255, 255, 255);
+  line-height: 1.5;
+  white-space: nowrap;
+}
+</style>
+{% endblock %}
+
+{% block iscompatible %}
+  return 'registerElement' in document;
+{% endblock %}
+
+{% block html5badge %}
+<!-- Your HTML5 badge (tech class icons used in the article) goes here -->
+{% endblock %}
+
+{% block share_image %}
+<!--<meta itemprop="image" content="images/your_social_sharing_img.png">-->
+{% endblock %}
+
+{% block translator %}
+<div class="translator">
+  <strong>翻译：</strong> <a href="http://forcefront.com/">米粽 (Leo Deng)</a>
+</div>
+{% endblock %}
+
+{% block content %}
+
+<p>{% include "warning.html" %}</p>
+<h2 id="intro">引言</h2>
+
+<p>现在的 web 严重缺乏表达能力。你只要瞧一眼“现代”的 web 应用，比如 GMail，就会明白我的意思：</p>
+<figure>
+  <a href="gmail.png"><img src="gmail.png" style="max-width:75%"></a>
+  <figcaption>现代 web 应用：使用 <code>&lt;div></code> 堆砌而成。</figcpation>
+</figure>
+
+<p>堆砌 <code>&lt;div&gt;</code> 一点都不现代。然而可悲的是，这就是我们构建 web 应用的方式。在现有基础上我们不应该有更高的追求吗？</p>
+<h3 id="meaningful">时髦的标记，行动起来！</h3>
+
+<p>HTML 为我们提供了一个完美的文档组织工具，然而 <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/">HTML 规范</a>定义的元素却很有限。</p>
+<p>假如 GMail 的标记不那么糟糕，而是像下面这样漂亮，那会怎样？</p>
+<pre class="prettyprint"><code>&lt;hangout-module&gt;
+  &lt;hangout-chat from="Paul, Addy"&gt;
+    &lt;hangout-discussion&gt;
+      &lt;hangout-message from="Paul" profile="profile.png"
+          profile="118075919496626375791" datetime="2013-07-17T12:02"&gt;
+        &lt;p&gt;Feelin' this Web Components thing.&lt;/p&gt;
+        &lt;p&gt;Heard of it?&lt;/p&gt;
+      &lt;/hangout-message&gt;
+    &lt;/hangout-discussion&gt;
+  &lt;/hangout-chat&gt;
+  &lt;hangout-chat&gt;...&lt;/hangout-chat&gt;
+&lt;/hangout-module&gt;
+</code></pre>
+<p class="centered">
+  <button><a href="https://html5-demos.appspot.com/hangouts">查看演示！</a></button>
+</p>
+
+<p>真是令人耳目一新！这个应用太合理了，既<strong>有意义</strong>，又<strong>容易理解</strong>。最妙的是，它是<strong>可维护</strong>的，只要查看声明结构就可以清楚地知道它的作用。</p>
+<blockquote class="commentary talkinghead">自定义元素，救救我们！就指望你了！</blockquote>
+
+<h2 id="gettingstarted">赶紧开始吧</h2>
+[自定义元素](http://w3c.github.io/webcomponents/spec/custom/)**允许开发者定义新的 HTML 元素类型**。该规范只是 [Web 组件](http://w3c.github.io/webcomponents/explainer/)模块提供的众多新 API 中的一个，但它也很可能是最重要的一个。缺少自定义元素带来的以下特性，Web 组件根本玩不转：
+<p><a href="http://w3c.github.io/webcomponents/spec/custom/">自定义元素</a>
+<strong>允许开发者定义新的 HTML 元素类型</strong>。该规范只是 <a href="http://w3c.github.io/webcomponents/explainer/">Web 组件</a>模块提供的众多新 API 中的一个，但它也很可能是最重要的一个。没有自定义元素带来的以下特性，Web 组件都不会存在：</p>
+<ol>
+<li>定义新的 HTML/DOM 元素</li>
+<li>基于其他元素创建扩展元素</li>
+<li>给一个标签绑定一组自定义功能</li>
+<li>扩展已有 DOM 元素的 API</li>
+</ol>
+<h3 id="registering">注册新元素</h3>
+
+<p>使用 <code>document.registerElement()</code> 可以创建一个自定义元素：</p>
+<pre class="prettyprint"><code>var XFoo = document.registerElement('x-foo');
+document.body.appendChild(new XFoo());
+</code></pre>
+
+<p><code>document.registerElement()</code> 的第一个参数是元素的标签名。这个标签名<strong>必须包括一个连字符（-）</strong>。因此，诸如 <code>&lt;x-tags&gt;</code>、<code>&lt;my-element&gt;</code> 和 <code>&lt;my-awesome-app&gt;</code> 都是合法的标签名，而 <code>&lt;tabs&gt;</code> 和 <code>&lt;foo_bar&gt;</code> 则不是。这个限定使解析器能很容易地区分自定义元素和 HTML 规范定义的元素，同时确保了 HTML 增加新标签时的向前兼容。</p>
+第二个参数是一个（可选的）对象，用于描述该元素的原型。在这里可以为元素添加自定义功能（例如：公开属性和方法）。稍后[详述](#publicapi)。
+<p>第二个参数是一个（可选的）对象，用于描述该元素的 <code>prototype</code>。在这里可以为元素添加自定义功能（例如：公开属性和方法）。稍后<a href="#publicapi">详述</a>。</p>
+<p>自定义元素默认继承自 <code>HTMLElement</code>，因此上一个示例等同于：</p>
+<pre class="prettyprint"><code>var XFoo = document.registerElement('x-foo', {
+  prototype: Object.create(HTMLElement.prototype)
+});
+</code></pre>
+<p>调用 <code>document.registerElement('x-foo')</code> 向浏览器注册了这个新元素，并返回一个可以用来创建 <code>&lt;x-foo&gt;</code> 元素实例的构造器。如果你不想使用构造器，也可以使用其他<a href="#instantiating">实例化元素的技术</a>。</p>
+<p class="notice tip">如果你不希望在 <code>window</code> 全局对象中创建元素构造器，还可以把它放进命名空间（<code>var myapp = {}; myapp.XFoo = document.registerElement('x-foo');</code>）。</p>
+
+<h3 id="extending">扩展原生元素</h3>
+
+<p>假设平淡无奇的原生 <code>&lt;button&gt;</code> 元素不能满足你的需求，你想将其增强为一个“超级按钮”，可以通过创建一个继承 <code>HTMLButtonElement.prototype</code> 的新元素，来扩展 <code>&lt;button&gt;</code> 元素：</p>
+<pre class="prettyprint"><code>var MegaButton = document.registerElement('mega-button', {
+  prototype: Object.create(HTMLButtonElement.prototype)
+});
+</code></pre>
+<p class="notice fact">要创建扩展自<b>元素 B</b> 的<b>元素 A</b>，<b>元素 A</b> 必须继承<b>元素 B</b> 的 <code>prototype</code>。</p>
+
+<p>这类自定义元素被称为<em>类型扩展自定义元素</em>。它们以继承某个特定 <code>HTMLElement</code> 的方式表达了“元素 X 是一个 Y”。</p>
+<p>示例：</p>
+<pre class="prettyprint"><code>&lt;button is="mega-button"&gt;
+</code></pre>
+<h3 id="upgrades">元素如何提升</h3>
+
+<p>你有没有想过为什么 HTML 解析器对非标准标签不报错？比如，我们在页面中声明一个 <code>&lt;randomtag&gt;</code>，一切都很和谐。根据 <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#htmlunknownelement">HTML 规范</a>的表述：</p>
+<blockquote>
+  非规范定义的元素必须使用 <code>HTMLUnknownElement</code> 接口。
+  <cite>HTML 规范</cite>
+</blockquote>
+
+<p><code>&lt;randomtag&gt;</code> 是非标准的，它会继承 <code>HTMLUnknownElement</code>。</p>
+<p>对自定义元素来说，情况就不一样了。<strong>拥有合法元素名的自定义元素将继承 <code>HTMLElement</code>。</strong>你可以按 <span class="kbd">Ctrl</span>+<span class="kbd">Shift</span>+<span class="kbd">J</span>（Mac 系统为 <span class="kbd">Cmd</span>+<span class="kbd">Opt</span>+<span class="kbd">J</span>）打开控制台，运行下面这段代码，得到的结果将是 <code>true</code>：</p>
+<pre class="prettyprint"><code>// “tabs”不是一个合法的自定义元素名
+document.createElement('tabs').__proto__ === HTMLUnknownElement.prototype
+
+// “x-tabs”是一个合法的自定义元素名
+document.createElement('x-tabs').__proto__ == HTMLElement.prototype
+</code></pre>
+<p class="notice fact">在不支持 <code>document.registerElement()</code> 的浏览器中，<code>&lt;x-tabs></code> 仍为 <code>HTMLUnknownElement</code>。
+
+<h4 id="unresolvedels">Unresolved 元素</h4>
+
+<p>由于自定义元素是通过脚本执行 <code>document.registerElement()</code> 注册的，因此 <strong>它们可能在元素定义被注册到浏览器<em>之前</em>就已经声明或创建过了</strong>。例如：你可以先在页面中声明 <code>&lt;x-tabs&gt;</code>，以后再调用 <code>document.registerElement('x-tabs')</code>。</p>
+<p>在被提升到其定义之前，这些元素被称为 <strong>unresolved 元素</strong>。它们是拥有合法自定义元素名的 HTML 元素，只是还没有注册成为自定义元素。</p>
+<p>下面这个表格看起来更直观一些：</p>
+<table>
+  <thead><tr><th>类型</th><th>继承自</th><th>示例</th></tr></thead>
+  <tr><td>unresolved 元素</td><td><code>HTMLElement</code></td><td><code>&lt;x-tabs></code>、<code>&lt;my-element></code>、<code>&lt;my-awesome-app></code></td></tr>
+  <tr><td>未知元素</td><td><code>HTMLUnknownElement</code></td><td><code>&lt;tabs></code>、<code>&lt;foo_bar></code>
+</td></tr>
+</table>
+
+<blockquote class="commentary talkinghead">把 unresolved 元素想象成尚处于中间状态，它们都是等待被浏览器提升的潜在候选者。浏览器说：“你具备一个新元素的全部特征，我保证会在赋予你定义的时候将你提升为一个元素”。</blockquote>
+
+<h2 id="instantiating">实例化元素</h2>
+
+<p>我们创建普通元素用到的一些技术也可以用于自定义元素。和所有标准定义的元素一样，自定义元素既可以在 HTML 中声明，也可以通过 JavaScript 在 DOM 中创建。</p>
+<h3 id="usecustomtag">实例化自定义标签</h3>
+
+<p><strong>声明</strong>元素：</p>
+<pre class="prettyprint"><code>&lt;x-foo&gt;&lt;/x-foo&gt;
+</code></pre>
+<p>在 JS 中<strong>创建 DOM</strong>：</p>
+<pre class="prettyprint"><code>var xFoo = document.createElement('x-foo');
+xFoo.addEventListener('click', function(e) {
+  alert('Thanks!');
+});
+</code></pre>
+<p>使用 <strong><code>new</code> 操作符</strong>：</p>
+<pre class="prettyprint"><code>var xFoo = new XFoo();
+document.body.appendChild(xFoo);
+</code></pre>
+<h3 id="usetypeextension">实例化类型扩展元素</h3>
+
+<p>实例化类型扩展自定义元素的方法和自定义标签惊人地相似。</p>
+<p><strong>声明</strong>元素：</p>
+<pre class="prettyprint"><code>&lt;!-- &lt;button&gt; “是一个”超级按钮 --&gt;
+&lt;button is="mega-button"&gt;
+</code></pre>
+<p>在 JS 中<strong>创建 DOM</strong>：</p>
+<pre class="prettyprint"><code>var megaButton = document.createElement('button', 'mega-button');
+// megaButton instanceof MegaButton === true
+</code></pre>
+<p>看，这是接收第二个参数为 <code>is=""</code> 属性的 <code>document.createElement()</code> 重载版本。</p>
+<p>使用 <strong><code>new</code> 操作符</strong>：</p>
+<pre class="prettyprint"><code>var megaButton = new MegaButton();
+document.body.appendChild(megaButton);
+</code></pre>
+<p>现在，我们已经学习了如何使用 <code>document.registerElement()</code> 来向浏览器注册一个新标签。但这还不够，接下来我们要向新标签添加属性和方法。</p>
+<h2 id="publicapi">添加 JS 属性和方法</h2>
+
+<p>自定义元素最强大的地方在于，你可以在元素定义中加入属性和方法，给元素绑定特定的功能。你可以把它想象成一种给你的元素创建公开 API 的方法。</p>
+<p>这里有一个完整的示例：</p>
+<pre class="prettyprint"><code>var XFooProto = Object.create(HTMLElement.prototype);
+
+// 1. 为 x-foo 创建 foo() 方法
+XFooProto.foo = function() {
+  alert('foo() called');
+};
+
+// 2. 定义一个只读的“bar”属性
+Object.defineProperty(XFooProto, "bar", {value: 5});
+
+// 3. 注册 x-foo 的定义
+var XFoo = document.registerElement('x-foo', {prototype: XFooProto});
+
+// 4. 创建一个 x-foo 实例
+var xfoo = document.createElement('x-foo');
+
+// 5. 插入页面
+document.body.appendChild(xfoo);
+</code></pre>
+<p>构造 <code>prototype</code> 的方法多种多样，如果你不喜欢上面这种方式，再看一个更简洁的例子：</p>
+<pre class="prettyprint"><code>var XFoo = document.registerElement('x-foo', {
+  prototype: Object.create(HTMLElement.prototype, {
+    bar: {
+      get: function() { return 5; }
+    },
+    foo: {
+      value: function() {
+        alert('foo() called');
+      }
+    }
+  })
+});
+</code></pre>
+<p>以上两种方式，第一种使用了 ES5 的 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty"><code>Object.defineProperty</code></a>，第二种则使用了 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/get">get/set</a>。</p>
+<h3 id="lifecycle">生命周期回调方法</h3>
+
+<p>元素可以定义特殊的方法，来注入其生存期内关键的时间点。这些方法各自有特定的名称和用途，它们被恰如其分地命名为<strong>生命周期回调</strong>：</p>
+<table class="table">
+  <thead>
+    <tr>
+      <th>回调名称</th>
+      <th>调用时间点</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>createdCallback</td>
+      <td>创建元素实例</td>
+    </tr>
+    <tr>
+      <td>attachedCallback</td>
+      <td>向文档插入实例</td>
+    </tr>
+    <tr>
+      <td>detachedCallback</td>
+      <td>从文档中移除实例</td>
+    </tr>
+    <tr>
+      <td>attributeChangedCallback(attrName, oldVal, newVal)</td>
+      <td>添加，移除，或修改一个属性</td>
+    </tr>
+  </tbody>
+</table>
+
+<p><strong>示例：</strong>为 <code>&lt;x-foo&gt;</code> 定义 <code>createdCallback()</code> 和 <code>attachedCallback()</code>：</p>
+<pre class="prettyprint"><code>var proto = Object.create(HTMLElement.prototype);
+
+proto.createdCallback = function() {...};
+proto.attachedCallback = function() {...};
+
+var XFoo = document.registerElement('x-foo', {prototype: proto});
+</code></pre>
+<p><strong>所有生命周期回调都是可选的</strong>，你可以只在需要关注的时间点定义它们。例如：假设你有一个很复杂的元素，它会在 <code>createdCallback()</code> 打开一个 IndexedDB 连接。在将其从 DOM 移除时，<code>detachedCallback()</code> 会做一些必要的清理工作。<strong>注意：</strong>不要过于依赖这些生命周期方法（比如用户直接关闭浏览器标签），仅将其作为可能的优化点。</p>
+
+<p>另一个生命周期回调的例子是为元素设置默认的事件监听器：</p>
+<pre class="prettyprint"><code>proto.createdCallback = function() {
+  this.addEventListener('click', function(e) {
+    alert('Thanks!');
+  });
+};
+</code></pre>
+<blockquote class="commentary talkinghead">如果你的元素太笨重，是不会有人用它的。生命周期回调可以帮你大忙！</blockquote>
+
+<h2 id="addingmarkup">添加标记</h2>
+
+<p>我们已经创建好 <code>&lt;x-foo&gt;</code> 并添加了 JavaScript API，但它还没有任何内容。不如我们给点 HTML 让它渲染？</p>
+<p><a href="#lifecycle">生命周期回调</a>在这个时候就派上用场了。我们甚至可以用 <code>createdCallback()</code> 给一个元素赋予一些默认的 HTML：</p>
+<pre class="prettyprint"><code>var XFooProto = Object.create(HTMLElement.prototype);
+
+XFooProto.createdCallback = function() {
+  this.innerHTML = "&lt;b&gt;I'm an x-foo-with-markup!&lt;/b&gt;";
+};
+
+var XFoo = document.registerElement('x-foo-with-markup', {prototype: XFooProto});
+</code></pre>
+<div class="demoarea">
+  <x-foo-with-markup></x-foo-with-markup>
+</div>
+
+<p>实例化这个标签并在 DevTools 中观察（右击，选择“审查元素”），可以看到如下结构：</p>
+<pre class="prettyprint"><code>▾&lt;x-foo-with-markup&gt;
+   &lt;b&gt;I'm an x-foo-with-markup!&lt;/b&gt;
+ &lt;/x-foo-with-markup&gt;
+</code></pre>
+<h3 id="shadowdom">用 Shadow DOM 封装内部实现</h3>
+
+<p><a href="/tutorials/webcomponents/shadowdom/">Shadow DOM</a> 本身是一个封装内容的强大工具，配合使用自定义元素就更神奇了！</p>
+<p>Shadow DOM 为自定义元素提供了：</p>
+<ol>
+<li>一种隐藏内部实现的方法，从而将用户与血淋淋的实现细节隔离开。</li>
+<li>简单有效的<a href="/tutorials/webcomponents/shadowdom-201/">样式隔离</a>。</li>
+</ol>
+<p>从 Shadow DOM 创建元素，跟创建一个渲染基础标记的元素非常类似，区别在于 <code>createdCallback()</code> 回调：</p>
+<pre class="prettyprint"><code>var XFooProto = Object.create(HTMLElement.prototype);
+
+XFooProto.createdCallback = function() {
+  // 1. 为元素附加一个 shadow root。
+  var shadow = this.createShadowRoot();
+
+  // 2. 填入标记。
+  shadow.innerHTML = "&lt;b&gt;I'm in the element's Shadow DOM!&lt;/b&gt;";
+};
+
+var XFoo = document.registerElement('x-foo-shadowdom', {prototype: XFooProto});
+</code></pre>
+<div class="demoarea">
+  <x-foo-shadowdom></x-foo-shadowdom>
+</div>
+
+<p>我们并没有直接设置 <code>&lt;x-foo-shadowdom&gt;</code> 的 <code>innerHTML</code>，而是为其创建了一个用于填充标记的 Shadow Root。在 DevTools 设置中勾选“Show Shadow DOM”，你就会看到一个可以展开的 <code>#shadow-root</code>：</p>
+
+<pre class="prettyprint"><code>▾&lt;x-foo-shadowdom&gt;
+   ▾#shadow-root
+     &lt;b&gt;I'm in the element's Shadow DOM!&lt;/b&gt;
+ &lt;/x-foo-shadowdom&gt;
+</code></pre>
+<p>这就是 Shadow Root！</p>
+<h3 id="fromtemplate">从模板创建元素</h3>
+
+<p><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting-1.html#the-template-element">HTML 模板</a>是另一组跟自定义元素完美融合的新 API。</p>
+<p><a href="/tutorials/webcomponents/template/"><code>&lt;template&gt;</code> element</a>可用于声明 DOM 片段。它们可以被解析并在页面加载后插入，以及延迟到运行时才进行实例化。模板是声明自定义元素结构的理想方案。</p>
+<p><strong>示例：</strong>注册一个由 <code>&lt;template&gt;</code> 和 Shadow DOM 创建的元素：</p>
+<pre class="prettyprint"><code>&lt;template id="sdtemplate"&gt;
+  &lt;style&gt;
+    p { color: orange; }
+  &lt;/style&gt;
+  &lt;p&gt;I'm in Shadow DOM. My markup was stamped from a &amp;lt;template&amp;gt;.&lt;/p&gt;
+&lt;/template&gt;
+
+&lt;script&gt;
+var proto = Object.create(HTMLElement.prototype, {
+  createdCallback: {
+    value: function() {
+      var t = document.querySelector('#sdtemplate');
+      var clone = document.importNode(t.content, true);
+      this.createShadowRoot().appendChild(clone);
+    }
+  }
+});
+document.registerElement('x-foo-from-template', {prototype: proto});
+&lt;/script&gt;
+</code></pre>
+<p><template id="sdtemplate">
+  <style>x-foo-from-template p { color: orange; }</style>
+  <p>I'm in Shadow DOM. My markup was stamped from a &lt;template&gt;.</p>
+</template></p>
+<div class="demoarea">
+  <x-foo-from-template></x-foo-from-template>
+</div>
+
+<p>短短几行做了很多事情，我们挨个来看都发生了些什么：</p>
+<ol>
+<li>我们在 HTML 中注册了一个新元素：<code>&lt;x-foo-from-template&gt;</code></li>
+<li>这个元素的 DOM 是从一个 <code>&lt;template&gt;</code> 创建的</li>
+<li>Shadow DOM 隐藏了该元素可怕的细节</li>
+<li>Shadow DOM 也对元素的样式进行了隔离（比如 <code>p {color: orange;}</code> 不会把整个页面都搞成<span style="color: orange;">橙色</span>）</li>
+</ol>
+<p>真不错！</p>
+<h2 id="styling">为自定义元素增加样式</h2>
+
+<p>和其他 HTML 标签一样，自定义元素也可以用选择器定义样式：</p>
+<pre class="prettyprint"><code>&lt;style&gt;
+  app-panel {
+    display: flex;
+  }
+  [is="x-item"] {
+    transition: opacity 400ms ease-in-out;
+    opacity: 0.3;
+    flex: 1;
+    text-align: center;
+    border-radius: 50%;
+  }
+  [is="x-item"]:hover {
+    opacity: 1.0;
+    background: rgb(255, 0, 255);
+    color: white;
+  }
+  app-panel &gt; [is="x-item"] {
+    padding: 5px;
+    list-style: none;
+    margin: 0 7px;
+  }
+&lt;/style&gt;
+
+&lt;app-panel&gt;
+  &lt;li is="x-item"&gt;Do&lt;/li&gt;
+  &lt;li is="x-item"&gt;Re&lt;/li&gt;
+  &lt;li is="x-item"&gt;Mi&lt;/li&gt;
+&lt;/app-panel&gt;
+</code></pre>
+<div class="demoarea" style="width:300px;">
+
+<app-panel>
+  <li is="x-item">Do</li>
+  <li is="x-item">Re</li>
+  <li is="x-item">Mi</li>
+</app-panel>
+</div>
+
+<h3 id="styling">为使用 Shadow DOM 的元素增加样式</h3>
+
+<p>有了 Shadow DOM 场面就热闹得多了，它可以<a href="#shadowdom">极大增强自定义元素的能力</a>。</p>
+<p>Shadow DOM 为元素增加了样式封装的特性。Shadow Root 中定义的样式不会暴露到宿主外部或对页面产生影响。<strong>对自定义元素来说，元素本身就是宿主。</strong>样式封装的属性也使得自定义元素能够为自己定义默认样式。</p>
+<p>Shadow DOM 的样式是一个很大的话题！如果你想更多地了解它，推荐你阅读我写的其他文章：</p>
+<ul>
+<li><a href="http://www.polymer-project.org">Polymer</a> 文档：<a href="http://www.polymer-project.org/articles/styling-elements.html">《元素样式指南》</a>。</li>
+<li>发表于 html5rocks.com 的<a href="/tutorials/webcomponents/shadowdom-201/">《Shadow DOM 201：CSS 和样式》</a>。</li>
+</ul>
+<h3 id="fouc">使用 :unresolved 伪类避免无样式内容闪烁（FOUC）</h3>
+
+<p>为了缓解<a href="http://en.wikipedia.org/wiki/Flash_of_unstyled_content">无样式内容闪烁</a>的影响，自定义元素规范提出了一个新的 CSS 伪类 <code>:unresolved</code>。在浏览器调用你的 <code>createdCallback()</code>（见<a href="#lifecycle">生命周期回调方法</a>一节）之前，这个伪类都可以匹配到<a href="#unresolvedels">unresolved 元素</a>。一旦产生调用，就意味着元素已经完成提升，成为它被定义的形态，该元素就不再是一个 unresolved 元素了。</p>
+
+<p class="notice">Chrome 29 已经原生支持 CSS <code>:unresolved</code> 伪类。</p>
+
+<p><strong>示例：</strong>注册后渐显的 <code>&lt;x-foo&gt;</code> 标签：</p>
+<pre class="prettyprint"><code>&lt;style&gt;
+  x-foo {
+    opacity: 1;
+    transition: opacity 300ms;
+  }
+  x-foo:unresolved {
+    opacity: 0;
+  }
+&lt;/style&gt;
+</code></pre>
+<p>请记住 <code>:unresolved</code> 伪类只能用于 <a href="#unresolvedels">unresolved 元素</a>，而不能用于继承自 <code>HTMLUnkownElement</code> 的元素（见<a href="#upgrades">元素如何提升</a>一节）。</p>
+<pre class="prettyprint"><code>&lt;style&gt;
+  /* 给所有 unresolved 元素添加边框 */
+  :unresolved {
+    border: 1px dashed red;
+    display: inline-block;
+  }
+  /* unresolved 元素 x-panel 的文本内容为红色 */
+  x-panel:unresolved {
+    color: red;
+  }
+  /* 定义注册后的 x-panel 文本内容为绿色 */
+  x-panel {
+    color: green;
+    display: block;
+    padding: 5px;
+    display: block;
+  }
+&lt;/style&gt;
+
+&lt;panel&gt;
+  I'm black because :unresolved doesn't apply to "panel".
+  It's not a valid custom element name.
+&lt;/panel&gt;
+
+&lt;x-panel&gt;I'm red because I match x-panel:unresolved.&lt;/x-panel&gt;
+</code></pre>
+<div class="demoarea">
+  <panel>I'm black because :unresolved doesn't apply to "panel". It's not a valid custom element name.</panel>
+  <x-panel>I'm red because I match x-panel:unresolved.</x-panel>
+  <p><button id="register-x-panel">Register &lt;x-panel></button></p>
+</div>
+
+<p>了解更多 <code>:unresolved</code> 伪类的知识，请看 Polymer 文档<a href="http://www.polymer-project.org/articles/styling-elements.html#preventing-fouc">《元素样式指南》</a>。</p>
+<h2 id="historysupport">历史和浏览器支持</h2>
+
+<h3 id="featuredetect">特性检测</h3>
+
+<p>特性检测就是检查 <code>document.registerElement()</code> 是否存在：</p>
+<pre class="prettyprint"><code>function supportsCustomElements() {
+  return 'registerElement' in document;
+}
+
+if (supportsCustomElements()) {
+  // Good to go!
+} else {
+  // Use other libraries to create components.
+}
+</code></pre>
+<h3 id="support">浏览器支持</h3>
+
+<p>Chrome 27 和 Firefox 23 都提供了对 <code>document.registerElement()</code> 的支持，不过之后规范又有一些演化。Chrome 31 将是第一个真正支持新规范的版本。</p>
+<p class="notice fact">在 Chrome 31 中使用自定义元素，需要开启 <code>about:flags</code> 中的“实验性 web 平台特性（Experimental Web Platform features）”选项。</p>
+
+<p>在浏览器支持稳定之前，也有一些很好的兼容方案：</p>
+<ul>
+<li>Google 的 <a href="http://polymer-project.org">Polymer</a> 集成了一个<a href="http://www.polymer-project.org/platform/custom-elements.html">兼容方案</a></li>
+<li>Mozilla 的 <a href="http://www.x-tags.org/">x-tags</a></li>
+</ul>
+<h3 id="elementel">HTMLElementElement 怎么了？</h3>
+
+<p>一直关注标准的人都知道曾经有一个 <code>&lt;element&gt;</code> 标签。它非常好用，你只要像下面这样就可以声明式地注册一个新元素：</p>
+<pre class="prettyprint"><code>&lt;element name="my-element"&gt;
+  ...
+&lt;/element&gt;
+</code></pre>
+<p>然而很不幸，在它的<a href="#upgrades">提升过程</a>、边界案例，以及末日般的复杂场景中，需要处理大量的时序问题。<code>&lt;element&gt;</code> 因此被迫搁置。2013 年 8 月，Dimitri Glazkov 在 <a href="http://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0287.html">public-webapps</a> 邮件组中宣告移除 <code>&lt;element&gt;</code>。</p>
+<p>值得注意的是，Polymer 实现了以 <code>&lt;polymer-element&gt;</code> 的形式声明式地注册元素。这是怎么做到的？它用的正是 <code>document.registerElement('polymer-element')</code> 以及我在<a href="#fromtemplate">从模板创建元素</a>一节介绍的技术。</p>
+<h2 id="conclusion">结语</h2>
+
+<p>自定义元素为我们提供了一个工具，通过它我们可以扩展 HTML 的词汇，赋予它新的特性，并把不同的 web 平台连接在一起。结合其他新的基本平台，如 Shadow DOM 和 <code>&lt;template&gt;</code>，我们领略了 web 组件的宏伟蓝图。标记语言将再次变得很时髦！</p>
+<p>如果你对使用 web 组件感兴趣，建议你看看 <a href="http://polymer-project.org">Polymer</a>，就它已经够你玩的了。</p>
+<script>
+if ('registerElement' in document) {
+  (function() {
+    if ('registerElement' in document) {
+      var XFooProto = Object.create(HTMLElement.prototype);
+
+      XFooProto.createdCallback = function() {
+        this.innerHTML = "<b>I'm an x-foo-with-markup!</b>";
+      };
+
+      var XFoo = document.registerElement('x-foo-with-markup', {prototype: XFooProto});
+    }
+  })();
+
+  (function() {
+    document.querySelector('#register-x-panel').addEventListener('click', function(e) {
+      var XFoo = document.registerElement('x-panel', {prototype: Object.create(HTMLElement.prototype)});
+      document.querySelector('x-panel').textContent = "x-panel is registered!";
+    });
+  })();
+}
+
+if ('createShadowRoot' in document.body && 'registerElement' in document) {
+
+(function() {
+    var XFooProto = Object.create(HTMLElement.prototype);
+
+    XFooProto.createdCallback = function() {
+      var shadow = this.createShadowRoot();
+      shadow.innerHTML = "<b>I'm in the element's Shadow DOM!</b>";
+    };
+
+    var XFoo = document.registerElement('x-foo-shadowdom', {prototype: XFooProto});
+})();
+
+(function() {
+  var proto = Object.create(HTMLElement.prototype, {
+    createdCallback: {
+      value: function() {
+        var t = document.querySelector('#sdtemplate');
+        var clone = document.importNode(t.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }
+    }
+  });
+  document.registerElement('x-foo-from-template', {prototype: proto});
+})();
+
+}
+</script><script>
+document.addEventListener('DOMContentLoaded', function(e) {
+  if (!isCompatible()) {
+    document.body.classList.add('disabledemos');
+  }
+});
+</script>
+{% endblock %}

--- a/content/tutorials/webcomponents/customelements/zh/index.md
+++ b/content/tutorials/webcomponents/customelements/zh/index.md
@@ -1,0 +1,574 @@
+{% include "warning.html" %}
+
+<h2 id="intro">引言</h2>
+
+现在的 web 严重缺乏表达能力。你只要瞧一眼“现代”的 web 应用，比如 GMail，就会明白我的意思：
+
+<figure>
+  <a href="gmail.png"><img src="gmail.png" style="max-width:75%"></a>
+  <figcaption>现代 web 应用：使用 <code>&lt;div></code> 堆砌而成。</figcpation>
+</figure>
+
+堆砌 `<div>` 一点都不现代。然而可悲的是，这就是我们构建 web 应用的方式。在现有基础上我们不应该有更高的追求吗？
+
+<h3 id="meaningful">时髦的标记，行动起来！</h3>
+
+HTML 为我们提供了一个完美的文档组织工具，然而 [HTML 规范](http://www.whatwg.org/specs/web-apps/current-work/multipage/)定义的元素却很有限。
+
+假如 GMail 的标记不那么糟糕，而是像下面这样漂亮，那会怎样？
+
+    <hangout-module>
+      <hangout-chat from="Paul, Addy">
+        <hangout-discussion>
+          <hangout-message from="Paul" profile="profile.png"
+              profile="118075919496626375791" datetime="2013-07-17T12:02">
+            <p>Feelin' this Web Components thing.</p>
+            <p>Heard of it?</p>
+          </hangout-message>
+        </hangout-discussion>
+      </hangout-chat>
+      <hangout-chat>...</hangout-chat>
+    </hangout-module>
+
+<p class="centered">
+  <button><a href="https://html5-demos.appspot.com/hangouts">查看演示！</a></button>
+</p>
+
+真是令人耳目一新！这个应用太合理了，既**有意义**，又**容易理解**。最妙的是，它是**可维护**的，只要查看声明结构就可以清楚地知道它的作用。
+
+<blockquote class="commentary talkinghead">自定义元素，救救我们！就指望你了！</blockquote>
+
+<h2 id="gettingstarted">赶紧开始吧</h2>
+
+[自定义元素](http://w3c.github.io/webcomponents/spec/custom/)**允许开发者定义新的 HTML 元素类型**。该规范只是 [Web 组件](http://w3c.github.io/webcomponents/explainer/)模块提供的众多新 API 中的一个，但它也很可能是最重要的一个。没有自定义元素带来的以下特性，Web 组件都不会存在：
+
+1. 定义新的 HTML/DOM 元素
+2. 基于其他元素创建扩展元素
+3. 给一个标签绑定一组自定义功能
+4. 扩展已有 DOM 元素的 API
+
+<h3 id="registering">注册新元素</h3>
+
+使用 `document.registerElement()` 可以创建一个自定义元素：
+
+    var XFoo = document.registerElement('x-foo');
+    document.body.appendChild(new XFoo());
+
+`document.registerElement()` 的第一个参数是元素的标签名。这个标签名**必须包括一个连字符（-）**。因此，诸如 `<x-tags>`、`<my-element>`、`<my-awesome-app>` 都是合法的标签名，而 `<tabs>` 和 `<foo_bar>` 则不是。这个限定使解析器能很容易地区分自定义元素和 HTML 规范定义的元素，同时确保了 HTML 增加新标签时的向前兼容。
+
+第二个参数是一个（可选的）对象，用于描述该元素的 `prototype`。在这里可以为元素添加自定义功能（例如：公开属性和方法）。稍后[详述](#publicapi)。
+
+自定义元素默认继承自 `HTMLElement`，因此上一个示例等同于：
+
+    var XFoo = document.registerElement('x-foo', {
+      prototype: Object.create(HTMLElement.prototype)
+    });
+
+调用 `document.registerElement('x-foo')` 向浏览器注册了这个新元素，并返回一个可以用来创建 `<x-foo>` 元素实例的构造器。如果你不想使用构造器，也可以使用其他[实例化元素的技术](#instantiating)。
+
+<p class="notice tip">如果你不希望在 <code>window</code> 全局对象中创建元素构造器，还可以把它放进命名空间（<code>var myapp = {}; myapp.XFoo = document.registerElement('x-foo');</code>）。</p>
+
+<h3 id="extending">扩展原生元素</h3>
+
+假设平淡无奇的原生 `<button>` 元素不能满足你的需求，你想将其增强为一个“超级按钮”，可以通过创建一个继承 `HTMLButtonElement.prototype` 的新元素，来扩展 `<button>` 元素：
+
+    var MegaButton = document.registerElement('mega-button', {
+      prototype: Object.create(HTMLButtonElement.prototype)
+    });
+
+<p class="notice fact">
+要创建扩展自<b>元素 B</b> 的<b>元素 A</b>，<b>元素 A</b> 必须继承<b>元素 B</b> 的 <code>prototype</code>。
+
+这类自定义元素被称为_类型扩展自定义元素_。它们以继承某个特定 `HTMLElement` 的方式表达了“元素 X 是一个 Y”。
+
+示例：
+
+    <button is="mega-button">
+
+<h3 id="upgrades">元素如何提升</h3>
+
+你有没有想过为什么 HTML 解析器对非标准标签不报错？比如，我们在页面中声明一个 `<randomtag>`，一切都很和谐。根据 [HTML 规范](http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#htmlunknownelement)的表述：
+
+<blockquote>
+  非规范定义的元素必须使用 <code>HTMLUnknownElement</code> 接口。
+  <cite>HTML 规范</cite>
+</blockquote>
+
+`<randomtag>` 是非标准的，它会继承 `HTMLUnknownElement`。
+
+对自定义元素来说，情况就不一样了。**拥有合法元素名的自定义元素将继承 `HTMLElement`。**你可以按 <span class="kbd">Ctrl</span>+<span class="kbd">Shift</span>+<span class="kbd">J</span>（Mac 系统为 <span class="kbd">Cmd</span>+<span class="kbd">Opt</span>+<span class="kbd">J</span>）打开控制台，运行下面这段代码，得到的结果将是 `true`：
+
+    // “tabs”不是一个合法的自定义元素名
+    document.createElement('tabs').__proto__ === HTMLUnknownElement.prototype
+
+    // “x-tabs”是一个合法的自定义元素名
+    document.createElement('x-tabs').__proto__ == HTMLElement.prototype
+
+<p class="notice fact">在不支持 <code>document.registerElement()</code> 的浏览器中，<code>&lt;x-tabs></code> 仍为 <code>HTMLUnknownElement</code>。
+
+<h4 id="unresolvedels">unresolved 元素</h4>
+
+由于自定义元素是通过脚本执行 `document.registerElement()` 注册的，因此**它们可能在元素定义被注册到浏览器_之前_就已经声明或创建过了**。例如：你可以先在页面中声明 `<x-tabs>`，以后再调用 `document.registerElement('x-tabs')`。
+
+在被提升到其定义之前，这些元素被称为 **unresolved 元素**。它们是拥有合法自定义元素名的 HTML 元素，只是还没有注册成为自定义元素。
+
+下面这个表格看起来更直观一些：
+
+<table>
+  <thead><tr><th>类型</th><th>继承自</th><th>示例</th></tr></thead>
+  <tr><td>unresolved 元素</td><td><code>HTMLElement</code></td><td><code>&lt;x-tabs></code>, <code>&lt;my-element></code>, <code>&lt;my-awesome-app></code></td></tr>
+  <tr><td>未知元素</td><td><code>HTMLUnknownElement</code></td><td><code>&lt;tabs></code>, <code>&lt;foo_bar></code>
+</td></tr>
+</table>
+
+<blockquote class="commentary talkinghead">把 unresolved 元素想象成尚处于中间状态，它们都是等待被浏览器提升的潜在候选者。浏览器说：“你具备一个新元素的全部特征，我保证会在赋予你定义的时候将你提升为一个元素”。</blockquote>
+
+<h2 id="instantiating">实例化元素</h2>
+
+我们创建普通元素用到的一些技术也可以用于自定义元素。和所有标准定义的元素一样，自定义元素既可以在 HTML 中声明，也可以通过 JavaScript 在 DOM 中创建。
+
+<h3 id="usecustomtag">实例化自定义标签</h3>
+
+**声明**元素：
+
+    <x-foo></x-foo>
+
+在 JS 中**创建 DOM**：
+
+    var xFoo = document.createElement('x-foo');
+    xFoo.addEventListener('click', function(e) {
+      alert('Thanks!');
+    });
+
+使用 **`new` 操作符**：
+
+    var xFoo = new XFoo();
+    document.body.appendChild(xFoo);
+
+<h3 id="usetypeextension">实例化类型扩展元素</h3>
+
+实例化类型扩展自定义元素的方法和自定义标签惊人地相似。
+
+**声明**元素：
+
+    <!-- <button> “是一个”超级按钮 -->
+    <button is="mega-button">
+
+在 JS 中**创建 DOM**：
+
+    var megaButton = document.createElement('button', 'mega-button');
+    // megaButton instanceof MegaButton === true
+
+看，这是接收第二个参数为 `is=""` 属性的 `document.createElement()` 重载版本。
+
+用 **`new` 操作符**实例化：
+
+    var megaButton = new MegaButton();
+    document.body.appendChild(megaButton);
+
+现在，我们已经学习了如何使用 `document.registerElement()` 来向浏览器注册一个新标签。但这还不够，接下来我们要向新标签添加属性和方法。
+
+<h2 id="publicapi">添加 JS 属性和方法</h2>
+
+自定义元素最强大的地方在于，你可以在元素定义中加入属性和方法，给元素绑定特定的功能。你可以把它想象成一种给你的元素创建公开 API 的方法。
+
+这里有一个完整的示例：
+
+    var XFooProto = Object.create(HTMLElement.prototype);
+
+    // 1. 为 x-foo 创建 foo() 方法
+    XFooProto.foo = function() {
+      alert('foo() called');
+    };
+
+    // 2. 定义一个只读的“bar”属性
+    Object.defineProperty(XFooProto, "bar", {value: 5});
+
+    // 3. 注册 x-foo 的定义
+    var XFoo = document.registerElement('x-foo', {prototype: XFooProto});
+
+    // 4. 创建一个 x-foo 实例
+    var xfoo = document.createElement('x-foo');
+
+    // 5. 插入页面
+    document.body.appendChild(xfoo);
+
+构造原型的方法多种多样，如果你不喜欢上面这种方式，再看一个更简洁的例子：
+
+    var XFoo = document.registerElement('x-foo', {
+      prototype: Object.create(HTMLElement.prototype, {
+        bar: {
+          get: function() { return 5; }
+        },
+        foo: {
+          value: function() {
+            alert('foo() called');
+          }
+        }
+      })
+    });
+
+以上两种方式，第一种使用了 ES5 的 [`Object.defineProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)，第二种则使用了 [get/set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/get)。
+
+<h3 id="lifecycle">生命周期回调方法</h3>
+
+元素可以定义特殊的方法，来注入其生存期内关键的时间点。这些方法各自有特定的名称和用途，它们被恰如其分地命名为**生命周期回调**：
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>回调名称</th>
+      <th>调用时间点</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>createdCallback</td>
+      <td>创建元素实例</td>
+    </tr>
+    <tr>
+      <td>attachedCallback</td>
+      <td>向文档插入实例</td>
+    </tr>
+    <tr>
+      <td>detachedCallback</td>
+      <td>从文档中移除实例</td>
+    </tr>
+    <tr>
+      <td>attributeChangedCallback(attrName, oldVal, newVal)</td>
+      <td>添加，移除，或修改一个属性</td>
+    </tr>
+  </tbody>
+</table>
+
+**示例：**为 `<x-foo>` 定义 `createdCallback()` 和 `attachedCallback()`：
+
+    var proto = Object.create(HTMLElement.prototype);
+
+    proto.createdCallback = function() {...};
+    proto.attachedCallback = function() {...};
+
+    var XFoo = document.registerElement('x-foo', {prototype: proto});
+
+**所有生命周期回调都是可选的**，你可以只在需要关注的时间点定义它们。例如：假设你有一个很复杂的元素，它会在 `createdCallback()` 打开一个 IndexedDB 连接。在将其从 DOM 移除时，`detachedCallback()` 会做一些必要的清理工作。**注意：**不要过于依赖这些生命周期方法（比如用户直接关闭浏览器标签），仅将其作为可能的优化点。
+
+另一个生命周期回调的例子是为元素设置默认的事件监听器：
+
+    proto.createdCallback = function() {
+      this.addEventListener('click', function(e) {
+        alert('Thanks!');
+      });
+    };
+
+<blockquote class="commentary talkinghead">如果你的元素太笨重，是不会有人用它的。生命周期回调可以帮你大忙！</blockquote>
+
+<h2 id="addingmarkup">添加标记</h2>
+
+我们已经创建好 `<x-foo>` 并添加了 JavaScript API，但它还没有任何内容。不如我们给点 HTML 让它渲染？
+
+[生命周期回调](#lifecycle)在这个时候就派上用场了。我们甚至可以用 `createdCallback()` 给一个元素赋予一些默认的 HTML：
+
+    var XFooProto = Object.create(HTMLElement.prototype);
+
+    XFooProto.createdCallback = function() {
+      this.innerHTML = "<b>I'm an x-foo-with-markup!</b>";
+    };
+
+    var XFoo = document.registerElement('x-foo-with-markup', {prototype: XFooProto});
+
+<div class="demoarea">
+  <x-foo-with-markup></x-foo-with-markup>
+</div>
+
+实例化这个标签并在 DevTools 中观察（右击，选择“审查元素”），可以看到如下结构：
+
+    ▾<x-foo-with-markup>
+       <b>I'm an x-foo-with-markup!</b>
+     </x-foo-with-markup>
+
+<h3 id="shadowdom">用 Shadow DOM 封装内部实现</h3>
+
+[Shadow DOM](/tutorials/webcomponents/shadowdom/) 本身是一个封装内容的强大工具，配合使用自定义元素就更神奇了！
+
+Shadow DOM 为自定义元素提供了：
+
+1. 一种隐藏内部实现的方法，从而将用户与血淋淋的实现细节隔离开。
+2. 简单有效的[样式隔离](/tutorials/webcomponents/shadowdom-201/)。
+
+从 Shadow DOM 创建元素，跟创建一个渲染基础标记的元素非常类似，区别在于 `createdCallback()` 回调：
+
+    var XFooProto = Object.create(HTMLElement.prototype);
+
+    XFooProto.createdCallback = function() {
+      // 1. 为元素附加一个 shadow root。
+      var shadow = this.createShadowRoot();
+
+      // 2. 填入标记。
+      shadow.innerHTML = "<b>I'm in the element's Shadow DOM!</b>";
+    };
+
+    var XFoo = document.registerElement('x-foo-shadowdom', {prototype: XFooProto});
+
+<div class="demoarea">
+  <x-foo-shadowdom></x-foo-shadowdom>
+</div>
+
+我们并没有直接设置 `<x-foo-shadowdom>` 的 `innerHTML`，而是为其创建了一个用于填充标记的 Shadow Root。在 DevTools 设置中勾选“Show Shadow DOM”，你就会看到一个可以展开的 `#shadow-root`：
+
+    ▾<x-foo-shadowdom>
+       ▾#shadow-root
+         <b>I'm in the element's Shadow DOM!</b>
+     </x-foo-shadowdom>
+
+这就是 Shadow Root！
+
+<h3 id="fromtemplate">从模板创建元素</h3>
+
+[HTML 模板](http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting-1.html#the-template-element) 是另一组跟自定义元素完美融合的新 API。
+
+[`<template>` 元素](/tutorials/webcomponents/template/)可用于声明 DOM 片段。它们可以被解析并在页面加载后插入，以及延迟到运行时才进行实例化。模板是声明自定义元素结构的理想方案。
+
+**示例：**注册一个由 `<template>` 和 Shadow DOM 创建的元素：
+
+    <template id="sdtemplate">
+      <style>
+        p { color: orange; }
+      </style>
+      <p>I'm in Shadow DOM. My markup was stamped from a &lt;template&gt;.</p>
+    </template>
+
+    <script>
+    var proto = Object.create(HTMLElement.prototype, {
+      createdCallback: {
+        value: function() {
+          var t = document.querySelector('#sdtemplate');
+          var clone = document.importNode(t.content, true);
+          this.createShadowRoot().appendChild(clone);
+        }
+      }
+    });
+    document.registerElement('x-foo-from-template', {prototype: proto});
+    </script>
+
+<template id="sdtemplate">
+  <style>x-foo-from-template p { color: orange; }</style>
+  <p>I'm in Shadow DOM. My markup was stamped from a &lt;template&gt;.</p>
+</template>
+
+<div class="demoarea">
+  <x-foo-from-template></x-foo-from-template>
+</div>
+
+短短几行做了很多事情，我们挨个来看都发生了些什么：
+
+1. 我们在 HTML 中注册了一个新元素：`<x-foo-from-template>`
+- 这个元素的 DOM 是从一个 `<template>` 创建的
+- Shadow DOM 隐藏了该元素可怕的细节
+- Shadow DOM 也对元素的样式进行了隔离（比如 `p {color: orange;}` 不会把整个页面都搞成<span style="color: orange;">橙色</span>）
+
+真不错！
+
+<h2 id="styling">为自定义元素增加样式</h2>
+
+和其他 HTML 标签一样，自定义元素也可以用选择器定义样式：
+
+    <style>
+      app-panel {
+        display: flex;
+      }
+      [is="x-item"] {
+        transition: opacity 400ms ease-in-out;
+        opacity: 0.3;
+        flex: 1;
+        text-align: center;
+        border-radius: 50%;
+      }
+      [is="x-item"]:hover {
+        opacity: 1.0;
+        background: rgb(255, 0, 255);
+        color: white;
+      }
+      app-panel > [is="x-item"] {
+        padding: 5px;
+        list-style: none;
+        margin: 0 7px;
+      }
+    </style>
+
+    <app-panel>
+      <li is="x-item">Do</li>
+      <li is="x-item">Re</li>
+      <li is="x-item">Mi</li>
+    </app-panel>
+
+<div class="demoarea" style="width:300px;">
+
+<app-panel>
+  <li is="x-item">Do</li>
+  <li is="x-item">Re</li>
+  <li is="x-item">Mi</li>
+</app-panel>
+</div>
+
+<h3 id="styling">为使用 Shadow DOM 的元素增加样式</h3>
+
+有了 Shadow DOM 场面就热闹得多了，它可以[极大增强自定义元素的能力](#shadowdom)。
+
+Shadow DOM 为元素增加了样式封装的特性。Shadow Root 中定义的样式不会暴露到宿主外部或对页面产生影响。**对自定义元素来说，元素本身就是宿主。**样式封装的属性也使得自定义元素能够为自己定义默认样式。
+
+Shadow DOM 的样式是一个很大的话题！如果你想更多地了解它，推荐你阅读我写的其他文章：
+
+- [Polymer](http://www.polymer-project.org) 文档：[《元素样式指南》](http://www.polymer-project.org/articles/styling-elements.html)。
+- 发表于 html5rocks.com 的[《Shadow DOM 201：CSS 和样式》](/tutorials/webcomponents/shadowdom-201/)。
+
+<h3 id="fouc">使用 :unresolved 伪类避免无样式内容闪烁（FOUC）</h3>
+
+为了缓解[无样式内容闪烁](http://en.wikipedia.org/wiki/Flash_of_unstyled_content)的影响，自定义元素规范提出了一个新的 CSS 伪类 `:unresolved`。在浏览器调用你的 `createdCallback()`（见[生命周期回调方法](#lifecycle)一节）之前，这个伪类都可以匹配到[unresolved 元素](#unresolvedels)。一旦产生调用，就意味着元素已经完成提升，成为它被定义的形态，该元素就不再是一个 unresolved 元素了。
+
+<p class="notice">Chrome 29 已经原生支持 CSS <code>:unresolved</code> 伪类。</p>
+
+**示例：**注册后渐显的 `<x-foo>` 标签：
+
+    <style>
+      x-foo {
+        opacity: 1;
+        transition: opacity 300ms;
+      }
+      x-foo:unresolved {
+        opacity: 0;
+      }
+    </style>
+
+请记住 `:unresolved` 伪类只能用于 [unresolved 元素](#unresolvedels)，而不能用于继承自 `HTMLUnkownElement` 的元素（见[元素如何提升](#upgrades)一节）。
+
+    <style>
+      /* 给所有 unresolved 元素添加边框 */
+      :unresolved {
+        border: 1px dashed red;
+        display: inline-block;
+      }
+      /* unresolved 元素 x-panel 的文本内容为红色 */
+      x-panel:unresolved {
+        color: red;
+      }
+      /* 定义注册后的 x-panel 文本内容为绿色 */
+      x-panel {
+        color: green;
+        display: block;
+        padding: 5px;
+        display: block;
+      }
+    </style>
+    
+    <panel>
+      I'm black because :unresolved doesn't apply to "panel".
+      It's not a valid custom element name.
+    </panel>
+
+    <x-panel>I'm red because I match x-panel:unresolved.</x-panel>
+
+<div class="demoarea">
+  <panel>I'm black because :unresolved doesn't apply to "panel". It's not a valid custom element name.</panel>
+  <x-panel>I'm red because I match x-panel:unresolved.</x-panel>
+  <p><button id="register-x-panel">Register &lt;x-panel></button></p>
+</div>
+
+了解更多 `:unresolved` 伪类的知识，请看 Polymer 文档[《元素样式指南》](http://www.polymer-project.org/articles/styling-elements.html#preventing-fouc)。
+
+
+<h2 id="historysupport">历史和浏览器支持</h2>
+
+<h3 id="featuredetect">特性检测</h3>
+
+特性检测就是检查 `document.registerElement()` 是否存在：
+    
+    function supportsCustomElements() {
+      return 'registerElement' in document;
+    }
+
+    if (supportsCustomElements()) {
+      // Good to go!
+    } else {
+      // Use other libraries to create components.
+    }
+
+<h3 id="support">浏览器支持</h3>
+
+Chrome 27 和 Firefox 23 都提供了对 `document.registerElement()` 的支持，不过之后规范又有一些演化。Chrome 31 将是第一个真正支持新规范的版本。
+
+<p class="notice fact">在 Chrome 31 中使用自定义元素，需要开启 <code>about:flags</code> 中的“实验性 web 平台特性（Experimental Web Platform features）”选项。</p>
+
+在浏览器支持稳定之前，也有一些很好的兼容方案：
+
+- Google 的 [Polymer](http://polymer-project.org) 集成了一个[兼容方案](http://www.polymer-project.org/platform/custom-elements.html)
+- Mozilla 的 [x-tags](http://www.x-tags.org/)
+
+<h3 id="elementel">HTMLElementElement 怎么了？</h3>
+
+一直关注标准的人都知道曾经有一个 `<element>` 标签。它非常好用，你只要像下面这样就可以声明式地注册一个新元素：
+
+    <element name="my-element">
+      ...
+    </element>
+
+然而很不幸，在它的[提升过程](#upgrades)、边界案例，以及末日般的复杂场景中，需要处理大量的时序问题。`<element>` 因此被迫搁置。2013 年 8 月，Dimitri Glazkov 在 [public-webapps](http://lists.w3.org/Archives/Public/public-webapps/2013JulSep/0287.html) 邮件组中宣告移除 `<element>`。
+
+值得注意的是，Polymer 实现了以 `<polymer-element>` 的形式声明式地注册元素。这是怎么做到的？它用的正是 `document.registerElement('polymer-element')` 以及我在[从模板创建元素](#fromtemplate)一节介绍的技术。
+
+<h2 id="conclusion">结语</h2>
+
+自定义元素为我们提供了一个工具，通过它我们可以扩展 HTML 的词汇，赋予它新的特性，并把不同的 web 平台连接在一起。结合其他新的基本平台，如 Shadow DOM 和 `<template>`，我们领略了 web 组件的宏伟蓝图。标记语言将再次变得很时髦！
+
+如果你对使用 web 组件感兴趣，建议你看看 [Polymer](http://polymer-project.org)，就它已经够你玩的了。
+
+<script>
+if ('registerElement' in document) {
+  (function() {
+    if ('registerElement' in document) {
+      var XFooProto = Object.create(HTMLElement.prototype);
+
+      XFooProto.createdCallback = function() {
+        this.innerHTML = "<b>I'm an x-foo-with-markup!</b>";
+      };
+
+      var XFoo = document.registerElement('x-foo-with-markup', {prototype: XFooProto});
+    }
+  })();
+
+  (function() {
+    document.querySelector('#register-x-panel').addEventListener('click', function(e) {
+      var XFoo = document.registerElement('x-panel', {prototype: Object.create(HTMLElement.prototype)});
+      document.querySelector('x-panel').textContent = "x-panel is registered!";
+    });
+  })();
+}
+
+if ('createShadowRoot' in document.body && 'registerElement' in document) {
+
+(function() {
+    var XFooProto = Object.create(HTMLElement.prototype);
+
+    XFooProto.createdCallback = function() {
+      var shadow = this.createShadowRoot();
+      shadow.innerHTML = "<b>I'm in the element's Shadow DOM!</b>";
+    };
+
+    var XFoo = document.registerElement('x-foo-shadowdom', {prototype: XFooProto});
+})();
+
+(function() {
+  var proto = Object.create(HTMLElement.prototype, {
+    createdCallback: {
+      value: function() {
+        var t = document.querySelector('#sdtemplate');
+        var clone = document.importNode(t.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }
+    }
+  });
+  document.registerElement('x-foo-from-template', {prototype: proto});
+})();
+
+}
+</script>
+


### PR DESCRIPTION
About 4 months ago I translated the article into Chinese and posted on [my blog](http://forcefront.com/2013/custom-elements-defining-new-elements-in-html/). Yesterday I just realized that I could contribute the localized version back to **HTML5Rocks** and benefit more people, especially developers from China and/or Chinese speakers in other countries and areas.
