### PR TITLE
Allowed copy+paste of headline

### DIFF
--- a/static/css/v2-article.css
+++ b/static/css/v2-article.css
@@ -85,6 +85,7 @@
   width: 100%;
   height: 100%;
   z-index: 0;
+  pointer-events: none;
   background: radial-gradient(circle farthest-side at top, rgba(255,255,255,0.45) 0%, rgba(255,255,255,0) 100%);
 }
 


### PR DESCRIPTION
This was missing a pointer-events: none; On Firefox I never could copy and paste the header text when pimping you on Twitter.
