### PR TITLE
Update “Building an amazing fullscreen mobile experience” to latest spec and add IE prefixes

### DIFF
--- a/content/mobile/fullscreen/en/index.html
+++ b/content/mobile/fullscreen/en/index.html
@@ -277,9 +277,19 @@ selector {
   display: none; // hides the element when not in fullscreen mode
 }</pre>
 
+<h4>Internet Explorer</h4>
+<p>In IE the CSS pseudo class lacks a hyphen, but otherwise works similarly to Chrome and Firefox.</p>
+
+<pre class="prettyprint">selector:-ms-fullscreen {
+  display: block;
+}
+
+selector {
+  display: none; // hides the element when not in fullscreen mode
+}</pre>
+
 <h4>Specification</h4>
-<p>The spelling in the specification differs slightly from the implementations in Chrome and Firefox, but the functionality is the same.
-</p>
+<p>The spelling in the specification matches the syntax used by IE.</p>
 
 <pre class="prettyprint">selector:fullscreen {
   display: block;


### PR DESCRIPTION
The article switches between old syntax and new syntax in a number of places. I updated them to the new syntax where relevant too. WebKit has supported the newer syntax for quite a while, so shouldn’t be an issue.
