### PR TITLE
fix for audio scheduling tutorial's bad tagging

### DIFF
--- a/content/tutorials/audio/scheduling/en/index.html
+++ b/content/tutorials/audio/scheduling/en/index.html
@@ -4,10 +4,8 @@
 
 {% block pagebreadcrumb %}{{ tut.title }}{% endblock %}
 
-{% block head %}
 {% block pagetitle %}A Tale of Two Clocks - Scheduling Web Audio with Precision{% endblock %}
 {% block date %}January 5, 2013{% endblock %}
-{% endblock %}
 
 {% block browsersupport %}
 <span class="browser opera supported"><span class="browser_name">Opera</span><span class="support">supported</span></span>

--- a/content/tutorials/audio/scheduling/ja/index.html
+++ b/content/tutorials/audio/scheduling/ja/index.html
@@ -4,10 +4,8 @@
 
 {% block pagebreadcrumb %}{{ tut.title }}{% endblock %}
 
-{% block head %}
 {% block pagetitle %}A Tale of Two Clocks - Scheduling Web Audio with Precision{% endblock %}
 {% block date %}January 5, 2013{% endblock %}
-{% endblock %}
 
 {% block browsersupport %}
 <span class="browser opera supported"><span class="browser_name">Opera</span><span class="support">supported</span></span>


### PR DESCRIPTION
http://www.html5rocks.com/en/tutorials/audio/scheduling/

is showing unexpected content on top. this will fix that.
