### PR TITLE
Translate 'datachannels' into Korean

### DIFF
--- a/content/tutorials/webrtc/datachannels/ko/index.html
+++ b/content/tutorials/webrtc/datachannels/ko/index.html
@@ -57,30 +57,30 @@ a[rel='external']
 {% block translator %}
 <div class="translator">
   <strong>번역:</strong> <a href="mailto:sbnet21@gmail.com">한순보 (Soonbo Han)</a>
- </div>
+</div>
 {% endblock %}
  
 {% block content %}
 
 
-<p>커뮤니케이션, 게임, 혹은 파일 전송을 위한 두 브라우저 간의 데이터 전송은 상당히 복잡한 과정이 될 수 있습니다. 데이터를 중계(relay)하기 위해 서버를 설정하고 비용을 지불하며, 아마 이를 여러 데이터 센터로의 확장하는 것이 필요할 것입니다. 이 시나리오는 높은 지연 시간(latency)의 가능성이 있고, 데이터를 비공개로 유지하는 것이 어렵습니다.</p>
+<p>커뮤니케이션, 게임, 혹은 파일 전송을 위한 두 브라우저 간의 데이터 전송은 상당히 복잡한 과정일 수 있습니다. 데이터를 중계(relay)하기 위해 서버를 설정하고 비용을 내야 하며, 아마도 이를 여러 데이터 센터로 확장할 필요가 있습니다. 이 시나리오는 높은 지연 시간(latency)의 가능성이 있고, 데이터를 비공개로 유지하는 것이 어렵습니다.</p>
 
 <p>한 피어(peer)에서 다른 곳으로 직접 데이터를 전달하기 위해 WebRTC의 RTCDataChannel API를 사용하면 이러한 문제들을 완화할 수 있습니다. 이 글에서는 데이터 채널을 설정하고 사용하는 기본적인 방법뿐만 아니라 오늘날 웹에서의 일반적인 사용 사례(use cases)를 다룹니다.</p>
 
   <blockquote class="notice tip">
-    <p>이 글을 최대한 활용하려면 RTCPeerConnection API에 대한 지식과 STUN, TURN 그리고 시그널링 작업에 대한 이해가 필요합니다. <a href="http://www.html5rocks.com/ko/tutorials/webrtc/basics/">Getting Started With WebRTC</a>를 살펴보는 것을 추천합니다.</p>
+    <p>이 글을 최대한 활용하려면 RTCPeerConnection API에 대한 지식과 STUN, TURN, 그리고 시그널링 작업에 대한 이해가 필요합니다. <a href="http://www.html5rocks.com/ko/tutorials/webrtc/basics/">Getting Started With WebRTC</a>를 살펴보는 것을 추천합니다.</p>
   </blockquote>
 
 
 <h2 id="why-another-data-channel">왜 또 다른 채널인가요?</h2>
 
 
-<p>우리는 <a href="http://www.html5rocks.com/ko/tutorials/websockets/basics/">WebSocket</a>, <a href="http://www.html5rocks.com/ko/tutorials/file/xhr2/">AJAX</a> 그리고 <a href="http://www.html5rocks.com/ko/tutorials/eventsource/basics/">Server Sent Events</a>가 있습니다. 왜 또 다른 커뮤니케이션 채널이 필요한가요? WebSocket은 양방향입니다. 하지만 이런 모든 기술은 서버로 혹은 서버로부터의 커뮤니케이션을 위해 디자인됩니다.</p>
+<p>우리에게는 <a href="http://www.html5rocks.com/ko/tutorials/websockets/basics/">WebSocket</a>, <a href="http://www.html5rocks.com/ko/tutorials/file/xhr2/">AJAX</a>, 그리고 <a href="http://www.html5rocks.com/ko/tutorials/eventsource/basics/">Server Sent Events</a>가 있습니다. 왜 또 다른 커뮤니케이션 채널이 필요한가요? WebSocket은 양방향입니다. 하지만 이런 모든 기술은 서버로 혹은 서버로부터의 커뮤니케이션을 위해 디자인됩니다.</p>
 
-<p>RTCDataChannel은 다른 접근을 취하고 있습니다.</p>
+<p>RTCDataChannel은 다른 접근법을 취합니다.</p>
 
 <ul>
-  <li>RTCPeerConnection API와 함께 동작하며, P2P(Peer To Peer) 연결을 가능하게 합니다. 이는 중개 서버가 없고 '홉(hops)'이 적어 지연 시간을 더 줄일 수 있습니다.</li>
+  <li>RTCPeerConnection API와 함께 동작하며, P2P(peer-to-peer) 연결을 가능하게 합니다. 이는 중개 서버가 없고 '홉(hops)'이 적어 지연 시간을 더 줄일 수 있습니다.</li>
   <li>RTCDataChannel은 <a href="https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol#Features">Stream Control Transmission Protocol</a> (SCTP)을 사용하여, 비순차 전송(out-of-order delivery)이나 재전송 설정(retransmit configuration)과 같은 설정가능한 전송 시멘틱스(semantics, 역자주: 의미)를 허용합니다.</li>
 </ul>
 
@@ -88,19 +88,19 @@ a[rel='external']
 
 <h2>경고: 시그널링, STUN과 TURN</h2>
 
-<p>비록 WebRTC가 피어투피어 커뮤니케이션을 가능하게 하지만 여전히 서버가 필요합니다.</p>
+<p>비록 WebRTC가 P2P 커뮤니케이션을 가능하게 하지만 여전히 서버는 필요합니다.</p>
 
 <ul>
-  <li><strong>시그널링을 위해</strong>, 미디어와 네트워크 메타데이터를 교환할 수 있게 하여 피어 연결을 초기화(Bootstrap, 역주: 초기 적재)합니다.</li>
+  <li><strong>시그널링을 위해</strong>, 미디어와 네트워크 메타데이터를 교환할 수 있게 하여 피어 연결을 부트스트랩(Bootstrap, 역주: 초기 로딩)합니다.</li>
   <li>피어 사이의 가능한 최고의 네트워크 경로를 설정하려고 ICS 프레임워크를 사용하고,  (각 피어의 공개적으로 접근 가능한 IP와 포트를 찾아내려고) STUN 서버와 (직접 연결이 실패하고 데이터 중계(relaying)가 필요하면) TURN 서버와 작업해서, <strong>NATs와 방화벽을 다룹니다</strong>.</li>
 </ul>
 
-<p>HTML5 Rocks의 글 <a href="http://www.html5rocks.com/ko/tutorials/webrtc/infrastructure/">WebRTC&nbsp;in&nbsp;the real world: STUN, TURN, and signaling</a>이 WebRTC가 시그널링과 네트워킹을 위해 서버와 작업하는 방법을 자세히 설명합니다.</p>
+<p>HTML5 Rocks의 글 <a href="http://www.html5rocks.com/ko/tutorials/webrtc/infrastructure/">WebRTC&nbsp;in&nbsp;the real world: STUN, TURN, and signaling</a>은 WebRTC가 시그널링과 네트워킹을 위해 서버와 작업하는 방법을 자세히 설명합니다.</p>
 
 <h2 id="the-capabilities">특성</h2>
 
 
-<p>RTCDataChannel API는 유연한 데이터 타입 집합을 지원합니다. 이 API는 WebSocket을 완전히 모방하여 디자인됐으며, RTCDataChannel은 <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-DOMString-data" title="W3C DOMString spec">문자열들</a>뿐만 아니라, <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-Blob-data" title="W3C Blob spec">Blob</a>, <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-ArrayBuffer-data" title="W3C ArrayBuffer spec">ArrayBuffer</a> 그리고 <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-ArrayBufferView-data" title="W3C ArrayBufferView spec">ArrayBufferView</a>와 같은 JavaScript의 바이너리 타입 일부를 지원합니다. 이 타입들은 파일 전송, 멀티플레이어 게임과 함께 동작 시 유용할 수 있습니다.</p>
+<p>RTCDataChannel API는 유연한 데이터 타입 집합을 지원합니다. 이 API는 WebSocket을 완전히 모방하여 디자인했으며, RTCDataChannel은 <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-DOMString-data" title="W3C DOMString spec">문자열</a>뿐만 아니라, <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-Blob-data" title="W3C Blob spec">Blob</a>, <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-ArrayBuffer-data" title="W3C ArrayBuffer spec">ArrayBuffer</a>, 그리고 <a href="http://www.w3.org/TR/webrtc/#widl-RTCDataChannel-send-void-ArrayBufferView-data" title="W3C ArrayBufferView spec">ArrayBufferView</a>와 같은 JavaScript의 바이너리 타입 일부를 지원합니다. 이 타입들을 파일 전송, 멀티플레이어 게임에서 사용하면 유용할 수 있습니다.</p>
 
 <table>
 <th>
@@ -135,7 +135,7 @@ a[rel='external']
 
 <p>패킷 손실이 없을 때 두 방식의 성능은 거의 같습니다. 하지만 신뢰성 있는 방식에서 패킷 손실은 그 패킷 뒤의 다른 패킷을 막는 원인이 되고, 그 손실 패킷은 그것을 재전송하고 도착할 때까지 오래된(stale) 패킷일 수 있습니다. 물론 같은 애플리케이션에, 각각 자신의 신뢰할 수 있는(혹은 없는) 시멘틱스를 가진 다수의 데이터 채널을 사용할 수 있습니다.</p>
 
-<p>아래에서 RTCDataChannel을 설정하여 신뢰성 있는 혹은 신뢰성 없는 방식을 사용하는 법을 보여드리도록 하겠습니다.</p>
+<p>아래에서 RTCDataChannel을 설정하여 신뢰성 있는 혹은 신뢰성 없는 방식을 사용하는 법을 살펴보겠습니다.</p>
 
 <h2 id="just-show-me-the-action">데이터 채널 설정하기</h2>
 
@@ -149,7 +149,7 @@ a[rel='external']
 
 <p>이 예제들에서 브라우저는 피어 연결을 자신에게 합니다. 그리고서 데이터 채널을 생성하고 피어 연결에 따라 메시지를 보냅니다. 결국 메시지가 페이지의 다른쪽 박스에 나타납니다!</p>
 
-<p>이것의 시작 코드는 다음과 같이 짧습니다.</p>
+<p>이것을 시작하는 코드는 다음과 같이 짧습니다.</p>
 
 <pre class="prettyprint">
 var peerConnection = new RTCPeerConnection();
@@ -195,21 +195,21 @@ var dataChannelOptions = {
   <li><strong>id:</strong> 채널에 대한 자신만의 ID를 제공하는 것을 허락</li>
 </ul>
 
-<p>대부분의 사람이 필요해서 사용할 옵션들은 처음 세 가지인 <code>ordered</code>, <code>maxRetransmitTime</code>, 그리고 <code>maxRetransmits</code>뿐입니다. (이제 WebRTC를 지원하는 모든 브라우저에서 사용하는) <a href="https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol" title="Wikipedia article about SCTP">SCTP</a>를 사용하면 신뢰성과 순차성을 기본으로 설정합니다. 애플리케이션 계층(layer)에서 완전한 제어를 원한다면 신뢰성이 완전히 없는(fully unreliable) 것을 사용하는 것이 이해되지만, 대부분 경우에는 부분적으로 신뢰성 있는(partially reliable) 것이 유용합니다.</p>
+<p>대부분의 사람이 필요해서 사용할 옵션은 처음 세 가지인 <code>ordered</code>, <code>maxRetransmitTime</code>, 그리고 <code>maxRetransmits</code>뿐입니다. (이제 WebRTC를 지원하는 모든 브라우저에서 사용하는) <a href="https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol" title="Wikipedia article about SCTP">SCTP</a>를 사용하면 신뢰성과 순차성을 기본으로 설정합니다. 애플리케이션 계층(layer)에서 완전한 제어를 원한다면 신뢰성이 완전히 없는(fully unreliable) 것을 사용하는 것이 이해되지만, 대부분 경우에는 부분적으로 신뢰성 있는(partially reliable) 것이 유용합니다.</p>
 
 <p>WebSocket을 사용할 때처럼 RTCDataChannel은 연결이 되거나, 끊기거나, 에러가 발생할 때와 다른 피어에서 메시지를 받았을 때 이벤트를 발생합니다.</p>
 
 <h2 id="is-it-safe">안전한가요?</h2>
 
-<p>암호화(Encryption)는 모든 WebRTC 컴포넌트에 필수적입니다. RTCDataChannel을 사용하면 모든 데이터가 <a href="https://en.wikipedia.org/wiki/Datagram_Transport_Layer_Security" title="Wikipedia article about DTLS">데이터그램 전송 계층 보안</a> (Datagram Transport Layer Security, DTLS)으로 안전해집니다. DTLS는 SSL에서 파생한 것으로, 표준 SSL 기반 연결을 사용하는 것만큼 데이터가 안전하다는 것을 의미합니다. DTLS는 표준화되었으며 WebRTC를 지원하는 모든 브라우저는 DTLS를 내장합니다. DTLS에 대한 더 많은 정보는 <a href="http://wiki.wireshark.org/DTLS">Wireshark wiki</a>에서 확인할 수 있습니다.</p>
+<p>암호화(Encryption)는 모든 WebRTC 컴포넌트에 필수입니다. RTCDataChannel을 사용하면 모든 데이터가 <a href="https://en.wikipedia.org/wiki/Datagram_Transport_Layer_Security" title="Wikipedia article about DTLS">데이터그램 전송 계층 보안</a> (Datagram Transport Layer Security, DTLS)으로 안전해집니다. DTLS는 SSL에서 파생한 것으로, 표준 SSL 기반 연결을 사용하는 것만큼 데이터가 안전하다는 것을 의미합니다. DTLS는 표준화된 것이며 WebRTC를 지원하는 모든 브라우저가 DTLS를 내장합니다. DTLS에 대한 더 많은 정보는 <a href="http://wiki.wireshark.org/DTLS">Wireshark wiki</a>에서 확인할 수 있습니다.</p>
 
 <h2 id="change-how-you-think-about-data">데이터에 대해 생각하는 방식을 바꾸세요</h2>
 
-<p>많은 양의 데이터를 다루는 것은 JavaScript에서 고통스러운 지점(pain point)일 수 있습니다. <a href="http://www.sharefest.me/">Sharefest</a>의 개발자들이 지적하듯, 새로운 방식으로 데이터를 생각할 필요가 있습니다. 사용 가능한 메모리양보다 더 큰 파일을 전송하려면, 정보를 저장하는 새로운 방식을 생각해야 합니다. 아래에서 보여주는 것처럼 <a href="http://www.html5rocks.com/ko/tutorials/file/filesystem/">FileSystem API</a> 같은 기술이 움직이기 시작할 때입니다.</p>
+<p>많은 양의 데이터를 다루는 것은 JavaScript에서 골칫거리(pain point)일 수 있습니다. <a href="http://www.sharefest.me/">Sharefest</a>의 개발자들이 지적하듯, 새로운 방식으로 데이터를 생각할 필요가 있습니다. 사용 가능한 메모리양보다 더 큰 파일을 전송하려면, 정보를 저장하는 새로운 방식을 생각해야 합니다. 아래에서 보여주는 것처럼 <a href="http://www.html5rocks.com/ko/tutorials/file/filesystem/">FileSystem API</a> 같은 기술이 움직임을 시작할 때입니다.</p>
 
-<h2 id="build-a-file-sharing-application">파일 공유 애플리케이션을 만들어 봅시다</h2>
+<h2 id="build-a-file-sharing-application">파일 공유 애플리케이션을 만들어 보세요</h2>
 
-<p>브라우저에서 파일을 공유할 수 있는 웹 애플리케이션을 만드는 것이 이제 RTCDataChannel을 사용하면 가능합니다. RTCDataChannel 상에서의 구축은 전송한 파일 데이터를 암호화하고, 애플리케이션 제공자의 서버를 건드리지 않는다는 것을 의미합니다. 이 기능으로 WebRTC 파일 공유는 더 신속한 공유를 위한 다수의 클라이언트와 연결될 가능성과 결합하여 웹을 위한 강력한 후보가 됩니다.</p>
+<p>브라우저에서 파일을 공유할 수 있는 웹 애플리케이션을 만드는 것이 이제 RTCDataChannel을 사용하면 가능합니다. RTCDataChannel 기반으로 만드는 것은 전송한 파일 데이터를 암호화하고, 애플리케이션 제공자의 서버를 건드리지 않는다는 것을 의미합니다. 이 기능은 더 신속한 공유를 위해 다수의 클라이언트와 연결할 가능성과 결합하여 WebRTC 파일 공유를 웹을 위한 강력한 후보로 만듭니다.</p>
 
 <p>성공적인 전송을 하려면 여러 단계가 필요합니다.</p>
 <ol style="list-style-type: decimal">
@@ -221,9 +221,9 @@ var dataChannelOptions = {
 <p>RTCDataChannel로 파일을 보내려고 시도할 때 고려할 여러 사항이 있습니다.</p>
 
 <ul>
-  <li><strong>파일 크기:</strong> 파일 크기가 충분히 작고 하나의 Blob으로 저장하고 로딩할 수 있으면, File API로 메모리에 로딩하고 신뢰성 있는 채널로 그 파일을 그대로 전달할 수 있습니다. (비록 브라우저가 최대 전송 크기에 대한 제한을 부여하고 있다는 것을 명심하더라도) 파일 크기가 커짐에 따라, 작업들은 좀 더 교묘해집니다. 청킹(Chunking) 메커니즘이 필요합니다. 파일 청크를 로딩하여 다른 피어에 보냅니다. chunkId 메타데이터를 수반하여 피어가 청크를 인식할 수 있습니다. 이 경우에 청크를 우선 (예를 들면 FileSystem API를 사용하여) 오프라인 저장소에 저장할 필요가 있고, 그 파일 전체를 갖게 되면 사용자 디스크에 저장합니다.</li>
-  <li><strong>속도:</strong> (UDP 같이) 신뢰성 없거나 (TCP 같이) 신뢰성 있는 전송이 파일 전송 작업에 더 나은지에 대해서는 논란의 여지가 있습니다. 애플리케이션이 일대일 파일 전송을 한다면, 신뢰성 없는 데이터 채널에 포함되는 것은 ACK/재전송 프로토콜을 위한 디자인에 약간의 노력이 필요합니다. 이것을 여러분 스스로 구현할 필요가 있으며, 여러분이 잘 만든다고 해도 신뢰성 있는 전송을 사용하는 것보다 훨씬 빠르지는 않습니다. 신뢰성 있고 비순차적인 것은 두 방면에서 최고를 제공해야 하지만, 결과는 멀티 파티(multi-party) (메쉬(mesh)) 파일 전송을 고려할 때의 상황에 따라 다를 수 있습니다.</li>
-  <li><strong>청크(Chunk) 크기:</strong> 청크는 애플리케이션의 데이터에서 가장 작은 '원자'입니다. (앞으로 나올 버전의 데이터 채널에서는 수정되겠지만) 현재 보내는 크기에 제한이 있기 때문에 청킹이 필요합니다. 현재 추천하는 최대 청크의 크기는 16KB입니다.</li>
+  <li><strong>파일 크기:</strong> 파일 크기가 충분히 작고 하나의 Blob으로 저장하고 로딩할 수 있으면, File API로 메모리에 로딩하고 신뢰성 있는 채널로 그 파일을 그대로 전달할 수 있습니다. (비록 브라우저가 최대 전송 크기에 대한 제한을 부여하고 있다는 것을 명심하더라도) 파일 크기가 커짐에 따라, 작업들은 좀 더 교묘해집니다. 청킹(chunking) 메커니즘이 필요합니다. 파일 청크(chunk)를 로딩하여 다른 피어에 보냅니다. chunkId 메타데이터를 동반하여 피어가 청크를 인식할 수 있습니다. 이 경우에 청크를 우선 (예를 들면 FileSystem API를 사용하여) 오프라인 저장소에 저장할 필요가 있고, 그 파일 전체를 갖게 되면 사용자 디스크에 저장합니다.</li>
+  <li><strong>속도:</strong> (UDP 같이) 신뢰성 없는 전송 혹은 (TCP 같이) 신뢰성 있는 전송이 파일 전송 작업에 더 나은지에 대해서는 논란의 여지가 있습니다. 애플리케이션이 일대일 파일 전송을 한다면, 신뢰성 없는 데이터 채널의 사용은 ACK/재전송 프로토콜을 위한 디자인 노력을 약간 필요로 합니다. 이것을 여러분 스스로 구현할 필요가 있으며, 여러분이 잘 만든다고 해도 신뢰성 있는 전송을 사용하는 것보다 훨씬 빠르지는 않습니다. 신뢰성 있고 비순차적인 것은 두 방면에서 최고를 제공해야 하지만, 결과는 멀티 파티(multi-party) (메쉬(mesh)) 파일 전송을 고려하면 상황에 따라 다를 수 있습니다.</li>
+  <li><strong>청크 크기:</strong> 청크는 애플리케이션의 데이터에서 가장 작은 '원자'입니다. (앞으로 나올 버전의 데이터 채널에서는 수정되겠지만) 현재 보내는 크기에 제한이 있기 때문에 청킹이 필요합니다. 현재 추천하는 최대 청크의 크기는 16KB입니다.</li>
 </ul>
 
 <p>파일을 완전히 다른 쪽으로 전송하면, 앵커(anchor) 태그를 사용해서 다운로드할 수 있습니다.</p>
@@ -246,7 +246,7 @@ function saveFile(blob) {
 <ul>
   <li>위에서 서술한 것처럼 P2P 파일 공유</li>
   <li>모질라의 <a href="https://hacks.mozilla.org/2013/03/webrtc-data-channels-for-great-multiplayer/">Banana Bread</a>에서 보듯이, WebGL 같은 다른 기술과 연결한 멀티플레이어 게임</li>
-  <li>콘텐츠 전송: 웹 리소스를 피어투피어 데이터 통신으로 전달하는 프레임워크. (<a href="https://peercdn.com/">PeerCDN</a>가 재발명된 것처럼)</li>
+  <li>콘텐츠 전송: 웹 리소스를 P2P 데이터 통신으로 전달하는 프레임워크 (<a href="https://peercdn.com/">PeerCDN</a>가 재발명된 것처럼)</li>
 </ul>
 
 <h2 id="change-the-way-you-build-applications">애플리케이션을 개발하는 방식을 바꾸세요</h2>
@@ -259,14 +259,14 @@ function saveFile(blob) {
 <h2 id="find-out-more">더 살펴보기</h2>
 
 <ul>
-  <li><a href="http://www.html5rocks.com/ko/tutorials/webrtc/basics/">WebRTC 시작하기</a></li>
-  <li><a href="http://www.html5rocks.com/ko/tutorials/webrtc/infrastructure/">WebRTC의 실제: STUN, TURN, 시그널링</a></li>
-  <li><a href="http://bit.ly/webrtcwebaudio">WebRTC resources</a></li>
-  <li><a href="http://www.w3.org/TR/webrtc/#peer-to-peer-data-api">W3C 작업 초안</a></li>
+  <li><a href="http://www.html5rocks.com/ko/tutorials/webrtc/basics/">Getting Started with WebRTC</a></li>
+  <li><a href="http://www.html5rocks.com/ko/tutorials/webrtc/infrastructure/">WebRTC in the real world: STUN, TURN and signaling</a></li>
+  <li><a href="http://bit.ly/webrtcwebaudio">WebRTC 자료</a></li>
+  <li><a href="http://www.w3.org/TR/webrtc/#peer-to-peer-data-api">W3C 작업 초안(Working Draft)</a></li>
   <li><a href="http://tools.ietf.org/html/draft-jesup-rtcweb-data-protocol-04">IETF WebRTC Data Channel Protocol 초안</a></li>
-  <li><a href="http://bloggeek.me/send-file-webrtc-data-api/">WebRTC Data API를 사용하여 파일을 어떻게 전송하는가</a></li>
-  <li><a href="http://bloggeek.me/webrtc-data-channel-uses/" title="bloggeek.me blog post by Tsahi Levent-Levi">WebRTC Data Channel의 7가지 창조적 사용례</a></li>
-  <li><a href="https://developer.mozilla.org/ko/demos/detail/bananabread" title="Banana Breat game">Banana Bread</a> JS와 WebGL로 컴파일된 첫 번째 3D 1인칭 슈팅 게임, WebRTC 데이터 채널을 멀티플레이어 방식으로 사용합니다.</li>
+  <li><a href="http://bloggeek.me/send-file-webrtc-data-api/">How to Send a File Using WebRTC Data API</a></li>
+  <li><a href="http://bloggeek.me/webrtc-data-channel-uses/" title="bloggeek.me blog post by Tsahi Levent-Levi">7 Creative Uses of WebRTC’s Data Channel</a></li>
+  <li><a href="https://developer.mozilla.org/ko/demos/detail/bananabread" title="Banana Breat game">Banana Bread</a> JS와 WebGL로 컴파일된 첫 번째 3D 1인칭 슈팅 게임으로 WebRTC 데이터 채널을 멀티플레이어 방식으로 사용</li>
 </ul>
 
 <p><strong>이 글을 준비하는데 도움을 준 Hadar Weiss and Shachar Zohar에게 감사드립니다.</strong></p>


### PR DESCRIPTION
Translated "WebRTC data channels for high performance data exchange" into Korean.
Thank @cwdoh for reviewing the initial draft.
