### PR TITLE
fix article 'speed/unnecessary-paints' page broken issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -431,6 +431,7 @@ class ContentHandler(webapp2.RequestHandler):
           'pt': 'Português (Brasil)',
           'ru': 'Pусский',
           'zh': '中文 (简体)',
+          'zh-TW': '中文（繁體）',
           'fa': 'فارسی'
         }
         loc_list = []


### PR DESCRIPTION
Sorry for not doing the 'make messages' and 'make compile'.
I didn't catch the point.
Yet I couldn't generate the locale files correctly after appending 'zh-TW' to the variable 'LANGUAGES' in the Makefile and 'make messages'. 
There seems to be some path issues. Does anyone can help?
