### PR TITLE
replaced +GoogleDevelopers with +GoogleChromeDevelopers publisher

### DIFF
--- a/templates/v2-base.html
+++ b/templates/v2-base.html
@@ -59,7 +59,7 @@
   {% if tut.second_author.google_account %}
   <link rel="author" href="https://www.google.com/profiles/{{tut.second_author.google_account}}">
   {% endif %}
-  <link rel="publisher" href="https://plus.google.com/111395306401981598462">
+  <link rel="publisher" href="https://plus.google.com/+GoogleChromeDevelopers">
 
   {% if localizations %}
   {% for alt_locale in localizations %}


### PR DESCRIPTION
This should add nice "Follow +GoogleChromeDevelopers" button on Google+ posts.
