### PR TITLE
hotfix: revive wrong translation of code 'ko'

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -24,7 +24,7 @@ LANGS = {
   'es': 'Español',
   'it': 'Italiano',
   'ja': '日本語',
-  'ko': '한국의',
+  'ko': '한국어',
   'pt': 'Português (Brasil)',
   'ru': 'Pусский',
   'zh': '中文 (简体)',


### PR DESCRIPTION
Fixed wrong translation of code 'ko', It was fixed at #660, but now it's revived.
