### PR TITLE
update the section on hi-res timestamp in the rAF article

### DIFF
--- a/content/tutorials/speed/animations/en/index.html
+++ b/content/tutorials/speed/animations/en/index.html
@@ -215,11 +215,11 @@ function calculateObjectMovement() {
 
 <h2 id="requestanimationframe-and-high-resolution-timestamps">requestAnimationFrame and High Resolution Timestamps</h2>
 
-<p>While we&rsquo;re spending some time talking about <code>requestAnimationFrame</code> it&rsquo;s worth noting a recent change to how callbacks are handled in Canary. Going forward the parameter passed to your callback function will be a high resolution timestamp, accurate to a fraction of a millisecond. Two things about this:</p>
+<p>While we&rsquo;re spending some time talking about <code>requestAnimationFrame</code> it&rsquo;s worth noting to how callbacks are handled. The parameter passed to your callback function is a high resolution timestamp, accurate to a fraction of a millisecond. Two things about this:</p>
 
 <ol>
   <li>It&rsquo;s awesome for your animations if they&rsquo;re time-based because now they can be really accurate</li>
-  <li>You&rsquo;ll need to update any code you have in place today that expects an object or element to be the first parameter</li>
+  <li>You need to update any code you have written that expects an object or element to be the first parameter</li>
 </ol>
 
 <p>Get the full rundown of this at: <a href="http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision">requestAnimationFrame API: now with sub-millisecond precision</a></p>


### PR DESCRIPTION
it's been quite a while since hi-res timestamp landed in the stable channel.
