### PR TITLE
Fix precision declaration

### DIFF
--- a/content/tutorials/webgl/webgl_fundamentals/en/index.html
+++ b/content/tutorials/webgl/webgl_fundamentals/en/index.html
@@ -252,7 +252,7 @@ void main() {
 <p>Then we supply a fragment shader to look up colors from the texture.</p>
 <pre class="prettyprint">
 &lt;script id="2d-fragment-shader" type="x-shader/x-fragment"&gt;
-precision float mediump;
+precision mediump float;
 
 // our texture
 uniform sampler2D u_image;


### PR DESCRIPTION
Fixes an simple typo that prevents the code from compiling - note how all the other examples in the tutorial also have the declaration in this order. =]
