### PR TITLE
Adding missing links

### DIFF
--- a/content/tutorials/speed/high-performance-animations/en/index.html
+++ b/content/tutorials/speed/high-performance-animations/en/index.html
@@ -5,10 +5,10 @@
 <aside class="panel">
   <h2>Related reading</h2>
   <ul>
-    <li><a href="#">Avoiding Unnecessary Paints</a></li>
-    <li><a href="#">Avoiding Unnecessary Paints: Animated GIF Edition</a></li>
-    <li><a href="#">Scrolling Performance</a></li>
-    <li><a href="#">Parallaxin'</a></li>
+    <li><a href="http://www.html5rocks.com/en/tutorials/speed/unnecessary-paints/">Avoiding Unnecessary Paints</a></li>
+    <li><a href="http://www.html5rocks.com/en/tutorials/speed/animated-gifs/">Avoiding Unnecessary Paints: Animated GIF Edition</a></li>
+    <li><a href="http://www.html5rocks.com/en/tutorials/speed/scrolling/">Scrolling Performance</a></li>
+    <li><a href="http://www.html5rocks.com/en/tutorials/speed/parallax/">Parallaxin'</a></li>
   </ul>
 </aside>
 {% endblock %}


### PR DESCRIPTION
"Related reading" section of the "High Performance Animations" article was missing links.
