### PR TITLE
Shadow DOM 201: Update CSS Variables syntax to the latest one.

### DIFF
--- a/content/tutorials/webcomponents/shadowdom-201/en/index.html
+++ b/content/tutorials/webcomponents/shadowdom-201/en/index.html
@@ -439,7 +439,7 @@ but loosened for custom pseudo element definitions.
 <p>Imagine a custom element author who marks out variable placeholders in their Shadow DOM. One for styling an internal button's font and another for its color:</p>
 <pre class="prettyprint"><code>button {
   color: --button-text-color, pink); /* default color will be pink */
-  font: var(--button-font);
+  font-family: var(--button-font);
 }
 </code></pre>
 <p>Then, the embedder of the element defines those values to their liking. Perhaps
@@ -463,7 +463,7 @@ var root = document.querySelector('#host').createShadowRoot();
 root.innerHTML = '&lt;style&gt;' + 
     'button {' + 
       'color: var(--button-text-color, pink);' + 
-      'font: var(--button-font);' + 
+      'font-family: var(--button-font);' + 
     '}' +
     '&lt;/style&gt;' +
     '&lt;content&gt;&lt;/content&gt;';

--- a/content/tutorials/webcomponents/shadowdom-201/en/index.md
+++ b/content/tutorials/webcomponents/shadowdom-201/en/index.md
@@ -334,7 +334,7 @@ Imagine a custom element author who marks out variable placeholders in their Sha
 
     button {
       color: var(--button-text-color, pink); /* default color will be pink */
-      font: var(--button-font);
+      font-family: var(--button-font);
     }
 
 Then, the embedder of the element defines those values to their liking. Perhaps
@@ -360,7 +360,7 @@ works beautifully! The whole picture looks like this:
     root.innerHTML = '<style>' + 
         'button {' + 
           'color: var(--button-text-color, pink);' + 
-          'font: var(--button-font);' + 
+          'font-family: var(--button-font);' + 
         '}' +
         '</style>' +
         '<content></content>';

--- a/content/tutorials/webcomponents/shadowdom-201/ja/index.html
+++ b/content/tutorials/webcomponents/shadowdom-201/ja/index.html
@@ -414,7 +414,7 @@ root.innerHTML = '&lt;div&gt;' +
 <p>Custom Element の作者が Shadow DOM に変数のプレースホルダーを用意した場合を想像してください。ひとつは内部のボタンに用いるフォント、もうひとつは色です：</p>
 <pre class="prettyprint"><code>button {
   color: var(--button-text-color, pink); /* デフォルトの色はピンク */
-  font: var(--button-font);
+  font-family: var(--button-font);
 }
 </code></pre>
 <p>そして、要素の利用者は好みに応じてその値を定義します。例えばページのテーマに合わせてカッコいい Comic Sans フォントを使うとか：</p>
@@ -436,7 +436,7 @@ var root = document.querySelector('#host').createShadowRoot();
 root.innerHTML = '&lt;style&gt;' + 
     'button {' + 
       'color: var(--button-text-color, pink);' + 
-      'font: var(--button-font);' + 
+      'font-family: var(--button-font);' + 
     '}' +
     '&lt;/style&gt;' +
     '&lt;content&gt;&lt;/content&gt;';

--- a/content/tutorials/webcomponents/shadowdom-201/ja/index.md
+++ b/content/tutorials/webcomponents/shadowdom-201/ja/index.md
@@ -302,7 +302,7 @@ Custom Element の作者が Shadow DOM に変数のプレースホルダーを�
 
     button {
       color: var(--button-text-color, pink); /* デフォルトの色はピンク */
-      font: var(--button-font);
+      font-family: var(--button-font);
     }
 
 そして、要素の利用者は好みに応じてその値を定義します。例えばページのテーマに合わせてカッコいい Comic Sans フォントを使うとか：
@@ -326,7 +326,7 @@ CSS Variables の継承に則って、全てが桃のように、美しくなり
     root.innerHTML = '<style>' + 
         'button {' + 
           'color: var(--button-text-color, pink);' + 
-          'font: var(--button-font);' + 
+          'font-family: var(--button-font);' + 
         '}' +
         '</style>' +
         '<content></content>';

--- a/content/tutorials/webcomponents/shadowdom-201/ko/index.html
+++ b/content/tutorials/webcomponents/shadowdom-201/ko/index.html
@@ -423,7 +423,7 @@ but loosened for custom pseudo element definitions.
 <p>그들의 Shadow DOM 내의 변수 플레이스홀더(Variable placeholder)들을 만드는 커스텀 엘리먼트 저작자를 상상해보시기 바랍니다. 다음과 같이 하나는 내부 버튼의 폰트를 스타일링하기 위한 것이고 다른 하나는 그에 대한 색상을 위한 것입니다.</p>
 <pre class="prettyprint"><code>button {
   color: var(--button-text-color, pink); /* default color will be pink */
-  font: var(--button-font);
+  font-family: var(--button-font);
 }
 </code></pre>
 <p>그리고나서, 엘리먼트의 내재자(embedder)는 연결을 위한 그 값들을 정의합니다. 아마도 그 자체 페이지에 대한 엄청나게 멋진 Comic Sans 테마와 매칭하기 위해 다음과 같이 할 것입니다.</p>
@@ -445,7 +445,7 @@ var root = document.querySelector('#host').createShadowRoot();
 root.innerHTML = '&lt;style&gt;' + 
     'button {' + 
       'color: var(--button-text-color, pink);' + 
-      'font: var(--button-font);' + 
+      'font-family: var(--button-font);' + 
     '}' +
     '&lt;/style&gt;' +
     '&lt;content&gt;&lt;/content&gt;';

--- a/content/tutorials/webcomponents/shadowdom-201/ko/index.md
+++ b/content/tutorials/webcomponents/shadowdom-201/ko/index.md
@@ -312,7 +312,7 @@ but loosened for custom pseudo element definitions.
 
     button {
       color: var(--button-text-color, pink); /* default color will be pink */
-      font: var(--button-font);
+      font-family: var(--button-font);
     }
 
 그리고나서, 엘리먼트의 내재자(embedder)는 연결을 위한 그 값들을 정의합니다. 아마도 그 자체 페이지에 대한 엄청나게 멋진 Comic Sans 테마와 매칭하기 위해 다음과 같이 할 것입니다.
@@ -336,7 +336,7 @@ CSS 변수들이 상속되는 방법으로 인해 모든 것이 아주 멋지고
     root.innerHTML = '<style>' + 
         'button {' + 
           'color: var(--button-text-color, pink);' + 
-          'font: var(--button-font);' + 
+          'font-family: var(--button-font);' + 
         '}' +
         '</style>' +
         '<content></content>';

--- a/content/tutorials/webcomponents/shadowdom-201/zh/index.html
+++ b/content/tutorials/webcomponents/shadowdom-201/zh/index.html
@@ -421,7 +421,7 @@ but loosened for custom pseudo element definitions.
 <p>想象一下，当一个自定义元素的作者在 Shadow DOM 中标记出变量的占位符。其中一个用于样式化内部按钮的字体，另一个用于样式化它的颜色：</p>
 <pre class="prettyprint"><code>button {
   color: var(--button-text-color, pink); /* default color will be pink */
-  font: var(--button-font);
+  font-family: var(--button-font);
 }
 </code></pre>
 <p>然后，元素的使用者按照自己的喜好定义了这些值。很可能是为了和他自己页面中非常酷的漫画字体主题(Comic Sans theme)相搭配： </p>
@@ -443,7 +443,7 @@ var root = document.querySelector('#host').createShadowRoot();
 root.innerHTML = '&lt;style&gt;' +
     'button {' +
       'color: var(--button-text-color, pink);' +
-      'font: var(--button-font);' +
+      'font-family: var(--button-font);' +
     '}' +
     '&lt;/style&gt;' +
     '&lt;content&gt;&lt;/content&gt;';

--- a/content/tutorials/webcomponents/shadowdom-201/zh/index.md
+++ b/content/tutorials/webcomponents/shadowdom-201/zh/index.md
@@ -307,7 +307,7 @@ but loosened for custom pseudo element definitions.
 
     button {
       color: var(--button-text-color, pink); /* default color will be pink */
-      font: var(--button-font);
+      font-family: var(--button-font);
     }
 
 然后，元素的使用者按照自己的喜好定义了这些值。很可能是为了和他自己页面中非常酷的漫画字体主题(Comic Sans theme)相搭配： 
@@ -331,7 +331,7 @@ but loosened for custom pseudo element definitions.
     root.innerHTML = '<style>' +
         'button {' +
           'color: var(--button-text-color, pink);' +
-          'font: var(--button-font);' +
+          'font-family: var(--button-font);' +
         '}' +
         '</style>' +
         '<content></content>';


### PR DESCRIPTION
The syntax for custom properties changed from `var-foo` to `--foo` in the latest spec. This updates the syntax used in examples. #1133
