### PR TITLE
Added missing email field to profile.yaml

### DIFF
--- a/database/profiles.yaml
+++ b/database/profiles.yaml
@@ -52,6 +52,7 @@ address:
 homepage: https://google.com/+viviancromwell
 google: 109147099159025717832
 twitter: viviancromwell
+email: 
 
 ---
 


### PR DESCRIPTION
Recently, whenever I try to initialize H5R on localhost via /database/load_all, GAE reported internal error. Because missing email field had been referred from main.py at line 640 like below.

``` python
twitter_account=profile.get('twitter'),
email=profile['email'], # HERE!
lanyrd=profile.get('lanyrd', False),
```

For avoiding this situation, I've inserted empty email field to that place. I don't know why it suddenly shows up. Anyway it needs to be checked before merging this PR.

cc @PaulKinlan
