### PR TITLE
fix width descriptor in picture element example

### DIFF
--- a/content/tutorials/responsive/picture-element/en/index.html
+++ b/content/tutorials/responsive/picture-element/en/index.html
@@ -326,7 +326,7 @@ can be applied to both <code>&lt;img&gt;</code> and <code>&lt;source&gt;</code> 
 &lt;picture&gt;
   &lt;source media="(min-width: 800px)"
           sizes="80vw"
-          srcset="lighthouse-landscape-640.jpg 6400w,
+          srcset="lighthouse-landscape-640.jpg 640w,
                   lighthouse-landscape-1280.jpg 1280w,
                   lighthouse-landscape-2560.jpg 2560w"&gt;
   &lt;img src="lighthouse-160.jpg" alt="lighthouse"


### PR DESCRIPTION
found an error in one of the code snippets in the picture element article while working on translating it.
