### PR TITLE
use document.importNode() instead of Node.cloneNode() in ShadowDOM

### DIFF
--- a/content/tutorials/webcomponents/shadowdom/en/index.html
+++ b/content/tutorials/webcomponents/shadowdom/en/index.html
@@ -327,7 +327,8 @@ populate the shadow root:
 &lt;script&gt;
 var shadow = document.querySelector('#nameTag').createShadowRoot();
 var template = document.querySelector('#nameTagTemplate');
-shadow.appendChild(template.content.cloneNode());
+var clone = document.importNode(template.content, true);
+shadow.appendChild(clone);
 &lt;/script&gt;
 </pre>
 

--- a/content/tutorials/webcomponents/shadowdom/ja/index.html
+++ b/content/tutorials/webcomponents/shadowdom/ja/index.html
@@ -290,7 +290,8 @@ DOM ツリーにはカプセル化の機能がありませんので、ネーム�
 &lt;script&gt;
 var shadow = document.querySelector('#nameTag').createShadowRoot();
 var template = document.querySelector('#nameTagTemplate');
-shadow.appendChild(template.content.cloneNode());
+var clone = document.importNode(template.content, true);
+shadow.appendChild(clone);
 &lt;/script&gt;
 </pre>
 

--- a/content/tutorials/webcomponents/shadowdom/ko/index.html
+++ b/content/tutorials/webcomponents/shadowdom/ko/index.html
@@ -307,8 +307,8 @@ DOM 트리는 불충분한 캡슐화를 가지고 있으므로 이름 태그의 
 &lt;script&gt;
 var shadow = document.querySelector('#nameTag').createShadowRoot();
 var template = document.querySelector('#nameTagTemplate');
-shadow.appendChild(template.content);
-template.remove();
+var clone = document.importNode(template.content, true);
+shadow.appendChild(clone);
 &lt;/script&gt;
 </pre>
 

--- a/content/tutorials/webcomponents/shadowdom/zh/index.html
+++ b/content/tutorials/webcomponents/shadowdom/zh/index.html
@@ -310,8 +310,8 @@ if (!HTMLElement.prototype.webkitCreateShadowRoot) {
 &lt;script&gt;
 var shadow = document.querySelector('#nameTag').createShadowRoot();
 var template = document.querySelector('#nameTagTemplate');
-shadow.appendChild(template.content);
-template.remove();
+var clone = document.importNode(template.content, true);
+shadow.appendChild(clone);
 &lt;/script&gt;
 </pre>
 


### PR DESCRIPTION
Updated ShadowDOM document as we recommend to use `document.importNode()` instead of `Node.cloneNode()`.
cc: @coonsta @cwdoh @sunnylost 
