### PR TITLE
Fixes typo in Shadow DOM 201 tutorial's CSS variables code snippet

### DIFF
--- a/content/tutorials/webcomponents/shadowdom-201/en/index.html
+++ b/content/tutorials/webcomponents/shadowdom-201/en/index.html
@@ -438,7 +438,7 @@ but loosened for custom pseudo element definitions.
 <p>A powerful way to create theming hooks will be through <a href="http://dev.w3.org/csswg/css-variables/">CSS Variables</a>. Essentially, creating "style placeholders" for other users to fill in.</p>
 <p>Imagine a custom element author who marks out variable placeholders in their Shadow DOM. One for styling an internal button's font and another for its color:</p>
 <pre class="prettyprint"><code>button {
-  color: --button-text-color, pink); /* default color will be pink */
+  color: var(--button-text-color, pink); /* default color will be pink */
   font-family: var(--button-font);
 }
 </code></pre>


### PR DESCRIPTION
Fixes issue #1295
