### PR TITLE
For cross-browser compatibility, use window.pageYOffset instead of window.scrollY

### DIFF
--- a/static/demos/parallax/demo-1a/scripts/parallax.js
+++ b/static/demos/parallax/demo-1a/scripts/parallax.js
@@ -15,11 +15,11 @@
   var mainBG = $('section#content');
 
   function onResize () {
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
   }
 
   function onScroll (evt) {
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
   }
 
   function updateElements (yPos) {
@@ -74,7 +74,7 @@
 
   (function() {
 
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
 
     blob1.classList.add('force-show');
     blob2.classList.add('force-show');

--- a/static/demos/parallax/demo-1b/scripts/parallax.js
+++ b/static/demos/parallax/demo-1b/scripts/parallax.js
@@ -30,7 +30,7 @@ window.requestAnimFrame = (function(){
   var lastScrollY = 0;
 
   function onResize () {
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
   }
 
   function onScroll (evt) {
@@ -38,7 +38,7 @@ window.requestAnimFrame = (function(){
     if(!ticking) {
       ticking = true;
       requestAnimFrame(updateElements);
-      lastScrollY = win.scrollY;
+      lastScrollY = win.pageYOffset;
     }
   }
 
@@ -95,7 +95,7 @@ window.requestAnimFrame = (function(){
 
   (function() {
 
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
 
     blob1.classList.add('force-show');
     blob2.classList.add('force-show');

--- a/static/demos/parallax/demo-2/scripts/parallax.js
+++ b/static/demos/parallax/demo-2/scripts/parallax.js
@@ -30,7 +30,7 @@ window.requestAnimFrame = (function(){
   var lastScrollY = 0;
 
   function onResize () {
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
   }
 
   function onScroll (evt) {
@@ -38,7 +38,7 @@ window.requestAnimFrame = (function(){
     if(!ticking) {
       ticking = true;
       requestAnimFrame(updateElements);
-      lastScrollY = win.scrollY;
+      lastScrollY = win.pageYOffset;
     }
   }
 
@@ -96,7 +96,7 @@ window.requestAnimFrame = (function(){
 
   (function() {
 
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
 
     blob1.classList.add('force-show');
     blob2.classList.add('force-show');

--- a/static/demos/parallax/demo-3/scripts/parallax.js
+++ b/static/demos/parallax/demo-3/scripts/parallax.js
@@ -38,14 +38,14 @@ window.requestAnimFrame = (function(){
     canvas.width = 960;
     canvas.height = window.innerHeight;
 
-    updateElements(win.scrollY);
+    updateElements(win.pageYOffset);
   }
 
   function onScroll (evt) {
     if(!ticking) {
       ticking = true;
       requestAnimFrame(updateElements);
-      lastScrollY = win.scrollY;
+      lastScrollY = win.pageYOffset;
     }
   }
 


### PR DESCRIPTION
For cross-browser compatibility, use window.pageYOffset instead of window.scrollY
