### PR TITLE
Changed 'subtlely' to 'subtly'

### DIFF
--- a/content/tutorials/es6/promises/en/index.html
+++ b/content/tutorials/es6/promises/en/index.html
@@ -154,7 +154,7 @@ Promise.all([img1.ready(), img2.ready()]).then(function() {
   <li><a href="https://github.com/tildeio/rsvp.js">RSVP.js</a></li>
 </ul>
 
-<p>The above and JavaScript promises share a common, standardised behaviour called <a href="https://github.com/promises-aplus/promises-spec">Promises/A+</a>. If you're a jQuery user, they have something similar called <a href="http://api.jquery.com/category/deferred-object/">Deferreds</a>. However, Deferreds aren't Promise/A+ compliant, which makes them <a href="https://thewayofcode.wordpress.com/tag/jquery-deferred-broken/">subtlely different and less useful</a>, so beware. jQuery also has <a href="http://api.jquery.com/Types/#Promise">a Promise type</a>, but this is just a subset of Deferred and has the same issues.</p>
+<p>The above and JavaScript promises share a common, standardised behaviour called <a href="https://github.com/promises-aplus/promises-spec">Promises/A+</a>. If you're a jQuery user, they have something similar called <a href="http://api.jquery.com/category/deferred-object/">Deferreds</a>. However, Deferreds aren't Promise/A+ compliant, which makes them <a href="https://thewayofcode.wordpress.com/tag/jquery-deferred-broken/">subtly different and less useful</a>, so beware. jQuery also has <a href="http://api.jquery.com/Types/#Promise">a Promise type</a>, but this is just a subset of Deferred and has the same issues.</p>
 <p>Although promise implementations follow a standardised behaviour, their overall APIs differ. JavaScript promises are similar in API to RSVP.js. Here's how you create a promise:</p>
 
 <pre class="prettyprint">var promise = new Promise(function(resolve, reject) {


### PR DESCRIPTION
Changed 
![image](https://cloud.githubusercontent.com/assets/7017045/5673430/aa048436-9750-11e4-90da-395bdff85400.png) to 
![image](https://cloud.githubusercontent.com/assets/7017045/5673434/b39ea3fa-9750-11e4-87b1-5aed17cdb70a.png)



Original Context: 
![image](https://cloud.githubusercontent.com/assets/7017045/5673419/8ea52bf0-9750-11e4-9c97-0b7070b7cc20.png)

After fixing the typo: 
![image](https://cloud.githubusercontent.com/assets/7017045/5673422/9afaae7a-9750-11e4-8ac9-55398b3c926e.png)
