### PR TITLE
Fix links in the template tutorial

### DIFF
--- a/content/tutorials/webcomponents/template/en/index.md
+++ b/content/tutorials/webcomponents/template/en/index.md
@@ -55,7 +55,7 @@ To create a templated content, declare some markup and wrap it in the `<template
 <blockquote class="commentary talkinghead">
 The observant reader may notice the empty image. That's perfectly fine
 and intentional. A broken image won't 404 or produce console errors because it
-won't be fetched on page load. We can dynamically generate the source URL later on. See 
+won't be fetched on page load. We can dynamically generate the source URL later on. See
 <a href="#toc-pillars">the pillars</a>.
 </blockquote>
 
@@ -89,7 +89,7 @@ but [content model](http://www.w3.org/TR/html5-diff/#content-model) children. It
 <h2 id="toc-using">Activating a template</h2>
 
 To use a template, you need to activate it. Otherwise its content will never render.
-The simplest way to do this is by creating a deep copy of its `.content` using `document.importNode()`. The `.content` property is a read-only `DocumentFragment` containing the guts of the template. 
+The simplest way to do this is by creating a deep copy of its `.content` using `document.importNode()`. The `.content` property is a read-only `DocumentFragment` containing the guts of the template.
 
     var t = document.querySelector('#mytemplate');
     // Populate the src at runtime.
@@ -144,7 +144,7 @@ runs when the button is pressed, stamping out the template.
 
 <h3 id="toc-demo-sd">Example: Creating Shadow DOM from a template</h3>
 
-Most people attach [Shadow DOM](/webcomponents/shadowdom/) to a host by setting a string of markup to `.innerHTML`:
+Most people attach [Shadow DOM](/tutorials/webcomponents/shadowdom/) to a host by setting a string of markup to `.innerHTML`:
 
     <div id="host"></div>
     <script>
@@ -170,7 +170,7 @@ content to a shadow root:
         border-radius: 5px;
         width: 450px;
         max-width: 100%;
-      } 
+      }
       :host(:hover) {
         background: #ccc;
       }
@@ -228,7 +228,7 @@ content to a shadow root:
     border-radius: 5px;
     width: 450px;
     max-width: 100%;
-  } 
+  }
   :host(:hover) {
     background: #ccc;
   }
@@ -306,7 +306,7 @@ The only time a template renders is when it goes live.
               <li>Stuff</li>
             </template>
           </ul>
-        </template> 
+        </template>
 
     Activating the outer template will not active inner templates. That is to say,
     nested templates require that their children also be manually activated.
@@ -335,7 +335,7 @@ While this technique works, there are a number of downsides. The rundown of this
 - <label class="bad"></label> *Not inert* - even though our content is hidden,
 a network request is still made for the image.
 - <label class="bad"></label> *Painful styling and theming* - an embedding page must prefix all of its
-CSS rules with `#mytemplate` in order to scope styles down to the template. This 
+CSS rules with `#mytemplate` in order to scope styles down to the template. This
 is brittle and there are no guarantees we won't encounter future naming collisions.
 For example, we're hosed if the embedding page already has an element with that id.
 

--- a/content/tutorials/webcomponents/template/it/index.md
+++ b/content/tutorials/webcomponents/template/it/index.md
@@ -66,7 +66,7 @@ Includere del contenuto in un`<template>` gode di alcune importanti proprietà.
 
 <h2 id="toc-using">Attivare un template</h2>
 
-Per usare un template, questo deve essere attivato, altrimenti il suo contenuto non sarà mai renderizzato. Il modo più semplice per attivare un template è creare una copia profonda del suo `.content`, utilizzando `cloneNode()`. `.content` è una proprietà in sola lettura cui fa riferimento `DocumentFragment`, contenente le interiora di un template. 
+Per usare un template, questo deve essere attivato, altrimenti il suo contenuto non sarà mai renderizzato. Il modo più semplice per attivare un template è creare una copia profonda del suo `.content`, utilizzando `cloneNode()`. `.content` è una proprietà in sola lettura cui fa riferimento `DocumentFragment`, contenente le interiora di un template.
 
     var t = document.querySelector('#mytemplate');
     // Populate the src at runtime.
@@ -118,7 +118,7 @@ Questo esempio mostra l'inerzia del contenuto di un template. Lo `<script>` vien
 
 <h3 id="toc-demo-sd">Esempio: Creare un DOM Shadow da un template</h3>
 
-Molte persone includono un [DOM Shadow](/webcomponents/shadowdom/) ad un host settando una stringa di markup a `.innerHTML`:
+Molte persone includono un [DOM Shadow](/tutorials/webcomponents/shadowdom/) ad un host settando una stringa di markup a `.innerHTML`:
 
     <div id="host"></div>
     <script>
@@ -141,7 +141,7 @@ Qualche volta sarebbe meglio lavorare direttamente sul DOM aggiungendo il conten
           border-radius: 5px;
           width: 450px;
           max-width: 100%;
-        } 
+        }
         *:hover {
           background: #ccc;
         }
@@ -201,7 +201,7 @@ Qualche volta sarebbe meglio lavorare direttamente sul DOM aggiungendo il conten
       border-radius: 5px;
       width: 450px;
       max-width: 100%;
-    } 
+    }
     *:hover {
       background: #ccc;
     }
@@ -275,7 +275,7 @@ Riporto alcuni problemi in cui mi sono imbattuto utilizzando `<template>` allo s
               <li>Stuff</li>
             </template>
           </ul>
-        </template> 
+        </template>
 
     L'attivazione del template più esterno non comporta l'attivazione del template interno. Ovvero, i template innestati richiedono che i figli siano attivati manualmente.
 

--- a/content/tutorials/webcomponents/template/ja/index.md
+++ b/content/tutorials/webcomponents/template/ja/index.md
@@ -122,7 +122,7 @@ HTML `<template>` 要素はあなたのマークアップ上のテンプレー�
 
 <h3 id="toc-demo-sd">例：テンプレートから Shadow DOM を作る</h3>
 
-ほとんどの人が [Shadow DOM](/webcomponents/shadowdom/) にホストを与える際、`.innerHTML` にマークアップの文字列をセットします：
+ほとんどの人が [Shadow DOM](/tutorials/webcomponents/shadowdom/) にホストを与える際、`.innerHTML` にマークアップの文字列をセットします：
 
     <div id="host"></div>
     <script>
@@ -144,7 +144,7 @@ HTML `<template>` 要素はあなたのマークアップ上のテンプレー�
         border-radius: 5px;
         width: 450px;
         max-width: 100%;
-      } 
+      }
       :host:hover {
         background: #ccc;
       }
@@ -202,7 +202,7 @@ HTML `<template>` 要素はあなたのマークアップ上のテンプレー�
     border-radius: 5px;
     width: 450px;
     max-width: 100%;
-  } 
+  }
   :host:hover {
     background: #ccc;
   }
@@ -275,9 +275,9 @@ HTML `<template>` 要素はあなたのマークアップ上のテンプレー�
               <li>Stuff</li>
             </template>
           </ul>
-        </template> 
+        </template>
 
-    外側の template をアクティベートしても、内側の template はアクティベートされません。これはつまり、ネストされたテンプレートは、内側の template も手動でアクティベートされている必要があるということを意味します。 
+    外側の template をアクティベートしても、内側の template はアクティベートされません。これはつまり、ネストされたテンプレートは、内側の template も手動でアクティベートされている必要があるということを意味します。
 
 <h2 id="toc-old">標準への道</h2>
 

--- a/content/tutorials/webcomponents/template/ko/index.md
+++ b/content/tutorials/webcomponents/template/ko/index.md
@@ -120,7 +120,7 @@ HTML `<template>` 엘리먼트는 여러분의 마크업에서 템플릿을 표�
 
 <h3 id="toc-demo-sd">예제: 템플릿으로부터 Shadow DOM 생성하기</h3>
 
-아래와 같이 대부분의 사람들은  `.innerHTML`로 마크업 문자열을 설정하는 것으로 [Shadow DOM](/webcomponents/shadowdom/)을 호스트에 붙입니다.
+아래와 같이 대부분의 사람들은  `.innerHTML`로 마크업 문자열을 설정하는 것으로 [Shadow DOM](/tutorials/webcomponents/shadowdom/)을 호스트에 붙입니다.
 
     <div id="host"></div>
     <script>
@@ -142,7 +142,7 @@ HTML `<template>` 엘리먼트는 여러분의 마크업에서 템플릿을 표�
         border-radius: 5px;
         width: 450px;
         max-width: 100%;
-      } 
+      }
       :host(:hover) {
         background: #ccc;
       }
@@ -200,7 +200,7 @@ HTML `<template>` 엘리먼트는 여러분의 마크업에서 템플릿을 표�
     border-radius: 5px;
     width: 450px;
     max-width: 100%;
-  } 
+  }
   :host(:hover) {
     background: #ccc;
   }
@@ -274,7 +274,7 @@ HTML `<template>` 엘리먼트는 여러분의 마크업에서 템플릿을 표�
               <li>Stuff</li>
             </template>
           </ul>
-        </template> 
+        </template>
 
     바깥 템플릿의 활성화는 내부 템플릿을 활성화하지 않습니다. 즉, 중첩된 템플릿들은 그들의 자식들 또한 수동으로 활성화하여야 합니다.
 

--- a/content/tutorials/webcomponents/template/zh/index.md
+++ b/content/tutorials/webcomponents/template/zh/index.md
@@ -126,7 +126,7 @@ HTML `<template>` 元素代表标记中的一个模板。它包含"模板内容"
 
 <h3 id="toc-demo-sd">例子：从模板中生成 Shadow DOM</h3>
 
-大部分人通过为 `.innerHTML` 赋值一串标记来将 [Shadow DOM](/webcomponents/shadowdom/) 挂载到 host 上：
+大部分人通过为 `.innerHTML` 赋值一串标记来将 [Shadow DOM](/tutorials/webcomponents/shadowdom/) 挂载到 host 上：
 
     <div id="host"></div>
     <script>


### PR DESCRIPTION
Fix wrong link to "Shadow DOM 101". There are some removed trailing spaces, which my editor did automatically.