### PR TITLE
Update html5parser.py

### DIFF
--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -1224,7 +1224,7 @@ class InBodyPhase(Phase):
         #has a namespace not equal to the xmlns attribute
         if self.parser.phase != self.parser.phases["inForeignContent"]:
             self.parser.secondaryPhase = self.parser.phase
-        self.parser.phase = self.parser.phases["inForeignContent"]
+            self.parser.phase = self.parser.phases["inForeignContent"]
         if token["selfClosing"]:
             self.tree.openElements.pop()
             token["selfClosingAcknowledged"] = True


### PR DESCRIPTION
If self.parser.phase and self.parser.phases["inForeignContent"] are equal, then don't need to allocate it again.