### PR TITLE
Update Promises article

### DIFF
--- a/content/tutorials/es6/promises/en/index.html
+++ b/content/tutorials/es6/promises/en/index.html
@@ -184,7 +184,7 @@ Promise.all([img1.ready(), img2.ready()]).then(function() {
 
 <h2 id="toc-browser-support">Browser support &amp; polyfill</h2>
 <p>There are already implementations of promises in browsers today.</p>
-<p>As of Chrome 32, Opera 19 Firefox 29, Safari 8 &amp; Microsoft Edge, promises are enabled by default.</p>
+<p>As of Chrome 32, Opera 19, Firefox 29, Safari 8 &amp; Microsoft Edge, promises are enabled by default.</p>
 
 <p>To bring browsers that lack a complete promises implementation up to spec compliance, or add promises to other browsers and Node.js, check out <a href="https://github.com/jakearchibald/ES6-Promises#readme">the polyfill</a> (2k gzipped).</p>
 

--- a/content/tutorials/es6/promises/en/index.html
+++ b/content/tutorials/es6/promises/en/index.html
@@ -184,7 +184,7 @@ Promise.all([img1.ready(), img2.ready()]).then(function() {
 
 <h2 id="toc-browser-support">Browser support &amp; polyfill</h2>
 <p>There are already implementations of promises in browsers today.</p>
-<p>As of Chrome 32, Opera 19 &amp; Firefox 29, promises are enabled by default. They're in WebKit nightlies so expect them in the next release of Safari, and they're <a href="http://status.modern.ie/promiseses6?term=promise">in development in IE</a>.</p>
+<p>As of Chrome 32, Opera 19 Firefox 29, Safari 8 &amp; Microsoft Edge, promises are enabled by default.</p>
 
 <p>To bring browsers that lack a complete promises implementation up to spec compliance, or add promises to other browsers and Node.js, check out <a href="https://github.com/jakearchibald/ES6-Promises#readme">the polyfill</a> (2k gzipped).</p>
 

--- a/content/tutorials/es6/promises/en/index.html
+++ b/content/tutorials/es6/promises/en/index.html
@@ -738,7 +738,7 @@ adder.next(50).value; // 65</pre>
   document.querySelector('.spinner').style.display = 'none';
 });</pre>
 
-<p>This works exactly as before, but so much easier to read. This works in Chrome and Opera today (<a href="async-generators-example.html">see example</a>), but first you need to go to <strong>about:flags</strong> and turn on <strong>Enable experimental JavaScript</strong>.</p>
+<p>This works exactly as before, but so much easier to read. This works in Chrome and Opera today (<a href="async-generators-example.html">see example</a>), and works in Microsoft Edge by going to <strong>about:flags</strong> and turning on the <strong>Enable experimental Javascript features</strong> setting. This will be enabled by default in an upcoming version.</p>
 
 <p>This throws together a lot of new ES6 stuff: promises, generators, let, for-of. When we yield a promise, the spawn helper waits for the promise to resolve and returns the final value. If the promise rejects, spawn causes our yield statement to throw an exception, which we can catch with normal JavaScript try/catch. Amazingly simple async coding!</p>
 
@@ -746,7 +746,7 @@ adder.next(50).value; // 65</pre>
 
 <h2 id="toc-api">Promise API Reference</h2>
 
-<p>All methods work in Chrome, Opera and in Firefox Nightly unless otherwise noted. <a href="https://github.com/jakearchibald/ES6-Promises#readme">The polyfill</a> provides the below for all browers.</p>
+<p>All methods work in Chrome, Opera, Firefox, Microsoft Edge, and Safari unless otherwise noted. <a href="https://github.com/jakearchibald/ES6-Promises#readme">The polyfill</a> provides the below for all browers.</p>
 
 <h3>Static Methods</h3>
 <dl>


### PR DESCRIPTION
@jakearchibald updated to mention latest support.

BTW, your generators test has syntax error in Firefox due to use of let.