### PR TITLE
Update content index to remove O.o

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -7,12 +7,12 @@
 {% block body %}
 
 <section class="masthead">
-  <a href="/{{LANGUAGE_CODE}}/tutorials/es7/observe/?utm_source=html5rocks&utm_medium=banner&utm_campaign=es7-observe">
+  <a href="https://developers.google.com/web/updates/2015/03/devtools-timeline-now-providing-the-full-story">
     <div class="container">
       <div id="image"></div>
       <h2>
-        <span class="small">Data-binding hell getting you down? Say hello to...</span>
-        <span class="large">Object.observe()</span>
+        <span class="small">Now providing the full story..</span>
+        <span class="large">DevTools Timeline</span>
         <span class="learnmore">Learn more</span>
       </h2>
     </div>


### PR DESCRIPTION
Replaces the homepage header content with a reference to the more recent DevTools Timeline article instead given we're deprecating O.o.

cc @PaulKinlan @ebidel 