### PR TITLE
Fixed #1431

### DIFF
--- a/static/css/v2-combined.css
+++ b/static/css/v2-combined.css
@@ -1145,6 +1145,7 @@ body.locked.article .content-wrapper:after {
 
   content: 'Fact!';
   background: #59B200;
+  border: 1px solid #59B200;
   line-height: 24px;
   color: #FFF;
   position: absolute;
@@ -1169,6 +1170,7 @@ body.locked.article .content-wrapper:after {
 .article .content-wrapper .warning:before {
   content: 'Heads up!';
   background: #ED4732;
+  border-color: #ED4732;
 }
 
 .article .content-wrapper .fact {
@@ -1196,6 +1198,7 @@ body.locked.article .content-wrapper:after {
 .article .content-wrapper .tip:before {
   content: 'Tip!';
   background: #00A3D9;
+  border-color: #00A3D9;
 }
 
 .article p {


### PR DESCRIPTION
I added an 1px solid border to:
`.article .content-wrapper .fact:before`, `.article .content-wrapper .warning:before` and `.article .content-wrapper .tip:before`.
The border-color is the same as the background color.
This antialises the element in Firefox 44.0.2.
