### PR TITLE
Remove dead link with ad-injected image

### DIFF
--- a/content/tutorials/webperformance/basics/en/index.html
+++ b/content/tutorials/webperformance/basics/en/index.html
@@ -185,12 +185,6 @@ window.onload = function(){
 
 <hr>
 
-<h2 id="addendum">Addendum</h2>
-
-2012.03.01: Kasia wrote a <a href="http://66.7percentangel.com/2011/12/breaking-down-onload-event-performance-bookmarklet/">very nice bookmarklet</a> to give a visual view of this data.
-
-<a href="http://66.7percentangel.com/2011/12/breaking-down-onload-event-performance-bookmarklet/"><img src="http://66.7percentangel.com/wp-content/uploads/2011/12/blah1-600x304.jpg"></a>
-
 
 <script>
 // Timeline class used for div#timeline chart.


### PR DESCRIPTION
The [Measuring Page Load Speed with Navigation Timing](https://www.html5rocks.com/en/tutorials/webperformance/basics/) page needed a bit of love:

- Removed dead link and corresponding image in #1461 

<img width="1440" alt="screen shot 2016-11-06 at 8 28 54 pm" src="https://cloud.githubusercontent.com/assets/5522075/20046897/da6e6cc8-a463-11e6-9c3f-33e66bc9ed17.png">