### PR TITLE
Notifications Tutorial: Updated Deprecation text

### DIFF
--- a/content/tutorials/notifications/quick/en/index.html
+++ b/content/tutorials/notifications/quick/en/index.html
@@ -6,7 +6,7 @@
 {% block pagetitle %}Using the Notifications API{% endblock %}
 {% block pagebreadcrumb %}Using the Notifications API{% endblock %}
 {% block date %}February 24th, 2010{% endblock %}
-{% block updated %}October 29, 2013{% endblock %}
+{% block updated %}February 6, 2017{% endblock %}
 
 {% block browsersupport %}
 <span class="browser opera"><span class="browser_name">Opera</span><span class="support">unsupported</span></span>

--- a/content/tutorials/notifications/quick/en/index.html
+++ b/content/tutorials/notifications/quick/en/index.html
@@ -26,7 +26,7 @@
 
 {% block content %}
   <p class="notice">
-    This article is outdated and references a deprecated API.<br><br> For modern coverage of the <a href="http://www.w3.org/TR/notifications/" target="_blank">Notifications API</a> (which is supported by Chrome, Firefox and Safari), read the <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification">MDN docs on Notification</a> and <a href="http://www.paulund.co.uk/html5-notifications">Paul Lund's Notification API tutorial</a>.   <a href="http://alxgbsn.co.uk/2013/02/20/notify-js-a-handy-wrapper-for-the-web-notifications-api/">Notify.js</a> also offers a nice abstraction for the API.
+    This article is outdated and references a deprecated API.<br><br> For modern coverage of the <a href="http://www.w3.org/TR/notifications/" target="_blank">Notifications API</a> (which is supported by Chrome, Firefox and Safari), read the <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification">MDN docs on Notification</a>.   <a href="https://github.com/alexgibson/notify.js">Notify.js</a> also offers a nice abstraction for the API.
 </p>
 
 <h2 id="toc-introduction">Introduction</h2>


### PR DESCRIPTION
 - Removed link to tutorial that discusses another outdated version of the standard.
 - Updated the link to Notify.js to point to the project itself.