### PR TITLE
webrtc infra: add note about TURN credentials

### DIFF
--- a/content/tutorials/webrtc/infrastructure/en/index.html
+++ b/content/tutorials/webrtc/infrastructure/en/index.html
@@ -496,6 +496,7 @@ node server.js
     }
   ]
 }</pre>
+<p><b>Note:</b> the TURN credentials example shown above was time-limited and expired in September 2013. TURN servers are expensive to run and you wіll need to pay for your own servers or find a service provider. To test credentials you can use the <a href="https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/">candidate gathering sample</a> and check if you get a candidate with type <i>relay</i>.</p>
 
 <p>Once RTCPeerConnection has that information, the ICE magic happens automatically: RTCPeerConnection uses the ICE framework to work out the best path between peers, working with STUN and TURN servers as necessary.</p>
 


### PR DESCRIPTION
adds a note about the TURN credentials. Those credentials
expired in September 2013 (the username is a timestamp)
yet people keep copying them around without bothering to
check if they work at all.