### PR TITLE
redirects CSS masking post

### DIFF
--- a/_redirects.yaml
+++ b/_redirects.yaml
@@ -53,3 +53,9 @@ redirects:
 
 - from: /tutorials/dnd/basics/
   to: https://web.dev/drag-and-drop/
+
+  - from: /tutorials/dnd/basics/
+  to: https://web.dev/drag-and-drop/
+
+  - from: /tutorials/masking/adobe/
+  to: https://web.dev/css-masking


### PR DESCRIPTION
Once my PR creating the new clipping and masking articles is merged: https://github.com/GoogleChrome/web.dev/pull/3819 this will redirect the masking and clipping post.

- https://github.com/GoogleChrome/web.dev/issues/3691
- https://github.com/GoogleChrome/web.dev/issues/3669